### PR TITLE
Improve WaveFrontSpanhandler

### DIFF
--- a/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/build.gradle
+++ b/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/build.gradle
@@ -29,9 +29,11 @@ dependencies {
 	implementation("com.wavefront:wavefront-internal-reporter-java")
 
 	// Tests
+	testImplementation project(':micrometer-tracing-test')
 	testImplementation 'org.junit.jupiter:junit-jupiter'
 	testImplementation 'org.assertj:assertj-core'
 	testImplementation 'org.awaitility:awaitility'
 	testImplementation 'ch.qos.logback:logback-classic'
+	testImplementation 'org.mockito:mockito-core'
 }
 

--- a/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/SpanMetrics.java
+++ b/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/SpanMetrics.java
@@ -28,10 +28,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public interface SpanMetrics {
 	/**
 	 * Is called when a span has been dropped.
-	 *
-	 * @return number of total dropped spans
 	 */
-	long reportDropped();
+	void reportDropped();
 
 	/**
 	 * Is called when a span is received.
@@ -61,11 +59,8 @@ public interface SpanMetrics {
 	 * No-op implementation.
 	 */
 	SpanMetrics NOOP = new SpanMetrics() {
-		private final AtomicLong dropped = new AtomicLong();
-
 		@Override
-		public long reportDropped() {
-			return dropped.incrementAndGet();
+		public void reportDropped() {
 		}
 
 		@Override

--- a/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/SpanMetrics.java
+++ b/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/SpanMetrics.java
@@ -17,18 +17,71 @@
 package io.micrometer.tracing.reporter.wavefront;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
+ * Reports metrics from {@link WavefrontSpanHandler}.
+ *
  * @author Moritz Halbritter
+ * @since 1.0.0
  */
 public interface SpanMetrics {
-    long reportDropped();
+	/**
+	 * Is called when a span has been dropped.
+	 *
+	 * @return number of total dropped spans
+	 */
+	long reportDropped();
 
-    void reportReceived();
+	/**
+	 * Is called when a span is received.
+	 */
+	void reportReceived();
 
-    void reportErrors();
+	/**
+	 * Is called when a span couldn't be sent.
+	 */
+	void reportErrors();
 
-    void registerQueueSize(BlockingQueue<?> queue);
+	/**
+	 * Registers the size of the given {@code queue}.
+	 *
+	 * @param queue queue which size should be registered
+	 */
+	void registerQueueSize(BlockingQueue<?> queue);
 
-    void registerQueueRemainingCapacity(BlockingQueue<?> queue);
+	/**
+	 * Registers the remaining capacity of the given {@code queue}.
+	 *
+	 * @param queue queue which remaining capacity should be registered
+	 */
+	void registerQueueRemainingCapacity(BlockingQueue<?> queue);
+
+	/**
+	 * No-op implementation.
+	 */
+	SpanMetrics NOOP = new SpanMetrics() {
+		private final AtomicLong dropped = new AtomicLong();
+
+		@Override
+		public long reportDropped() {
+			return dropped.incrementAndGet();
+		}
+
+		@Override
+		public void reportReceived() {
+		}
+
+		@Override
+		public void reportErrors() {
+		}
+
+		@Override
+		public void registerQueueSize(BlockingQueue<?> queue) {
+		}
+
+		@Override
+		public void registerQueueRemainingCapacity(BlockingQueue<?> queue) {
+		}
+	};
 }

--- a/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandler.java
+++ b/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandler.java
@@ -32,6 +32,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Iterators;
@@ -139,6 +140,8 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
     private final SpanMetrics spanMetrics;
 
     private final AtomicBoolean stop = new AtomicBoolean();
+
+	private final AtomicLong spansDropped = new AtomicLong();
 
     /**
      * @param maxQueueSize maximal span queue size
@@ -266,7 +269,7 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
 			this.spanMetrics.reportDropped();
 		} else {
 			if (!spanBuffer.offer(new SpanToSend(context, span))) {
-				long dropped = this.spanMetrics.reportDropped();
+				long dropped = this.spansDropped.incrementAndGet();
 				if (LOG.isWarnEnabled()) {
 					LOG.warn("Buffer full, dropping span: " + span);
 					LOG.warn("Total spans dropped: " + dropped);

--- a/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandler.java
+++ b/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandler.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Iterators;
@@ -113,7 +114,7 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
 
     private static final byte[] DECODING = buildDecodingArray();
 
-    private final LinkedBlockingQueue<Pair<TraceContext, FinishedSpan>> spanBuffer;
+    private final LinkedBlockingQueue<SpanToSend> spanBuffer;
 
     private final WavefrontSender wavefrontSender;
 
@@ -137,7 +138,7 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
 
     private final SpanMetrics spanMetrics;
 
-    private volatile boolean stop = false;
+    private final AtomicBoolean stop = new AtomicBoolean();
 
     /**
      * @param maxQueueSize maximal span queue size
@@ -259,14 +260,19 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
      * @return should other handler be ran
      */
     public boolean end(TraceContext context, FinishedSpan span) {
-        this.spanMetrics.reportReceived();
-        if (!spanBuffer.offer(Pair.of(context, span))) {
-            long dropped = this.spanMetrics.reportDropped();
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("Buffer full, dropping span: " + span);
-                LOG.warn("Total spans dropped: " + dropped);
-            }
-        }
+		this.spanMetrics.reportReceived();
+		if (stop.get()) {
+			LOG.warn("Trying to send span after close() have been called, dropping span");
+			this.spanMetrics.reportDropped();
+		} else {
+			if (!spanBuffer.offer(new SpanToSend(context, span))) {
+				long dropped = this.spanMetrics.reportDropped();
+				if (LOG.isWarnEnabled()) {
+					LOG.warn("Buffer full, dropping span: " + span);
+					LOG.warn("Total spans dropped: " + dropped);
+				}
+			}
+		}
         return true; // regardless of error, other handlers should run
     }
 
@@ -354,10 +360,14 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
 
     @Override
     public void run() {
-        while (!stop) {
+        while (!stop.get()) {
             try {
-                Pair<TraceContext, FinishedSpan> contextAndSpan = spanBuffer.take();
-                send(contextAndSpan._1, contextAndSpan._2);
+                SpanToSend spanToSend = spanBuffer.take();
+                if (spanToSend instanceof DeathPill) {
+					LOG.info("reporting thread stopping");
+					return;
+				}
+				send(spanToSend.getTraceContext(), spanToSend.getFinishedSpan());
             }
             catch (InterruptedException ex) {
                 if (LOG.isInfoEnabled()) {
@@ -372,16 +382,51 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
 
     @Override
     public void close() {
-        stop = true;
+		if (!stop.compareAndSet(false, true)) {
+			// Ignore multiple stop calls
+			return;
+		}
+
         try {
-            // wait for 5 secs max
-            sendingThread.join(5000);
+            // This will release the thread if it's waiting in BlockingQueue#take()
+			spanBuffer.offer(new DeathPill());
+			// wait for 5 secs max to send remaining spans
+			sendingThread.join(5000);
+			sendingThread.interrupt();
             heartbeatMetricsScheduledExecutorService.shutdownNow();
         }
         catch (InterruptedException ex) {
             // no-op
         }
     }
+
+	static class SpanToSend {
+		private final TraceContext traceContext;
+		private final FinishedSpan finishedSpan;
+
+		SpanToSend(TraceContext traceContext, FinishedSpan finishedSpan) {
+			this.traceContext = traceContext;
+			this.finishedSpan = finishedSpan;
+		}
+
+		TraceContext getTraceContext() {
+			return traceContext;
+		}
+
+		FinishedSpan getFinishedSpan() {
+			return finishedSpan;
+		}
+	}
+
+	/**
+	 * Gets queued into {@link #spanBuffer} if {@link #close()} is called and will lead
+	 * the sender thread to stop.
+	 */
+	static class DeathPill extends SpanToSend {
+		DeathPill() {
+			super(null, null);
+		}
+	}
 
     /**
      * Extracted for test isolation and as parsing otherwise implies multiple-returns or

--- a/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandler.java
+++ b/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandler.java
@@ -400,7 +400,7 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
         }
     }
 
-	static class SpanToSend {
+	private static class SpanToSend {
 		private final TraceContext traceContext;
 		private final FinishedSpan finishedSpan;
 
@@ -422,7 +422,7 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
 	 * Gets queued into {@link #spanBuffer} if {@link #close()} is called and will lead
 	 * the sender thread to stop.
 	 */
-	static class DeathPill extends SpanToSend {
+	private static class DeathPill extends SpanToSend {
 		DeathPill() {
 			super(null, null);
 		}

--- a/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandler.java
+++ b/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/main/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandler.java
@@ -363,7 +363,7 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
         while (!stop.get()) {
             try {
                 SpanToSend spanToSend = spanBuffer.take();
-                if (spanToSend instanceof DeathPill) {
+                if (spanToSend == DeathPill.INSTANCE) {
 					LOG.info("reporting thread stopping");
 					return;
 				}
@@ -389,7 +389,7 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
 
         try {
             // This will release the thread if it's waiting in BlockingQueue#take()
-			spanBuffer.offer(new DeathPill());
+			spanBuffer.offer(DeathPill.INSTANCE);
 			// wait for 5 secs max to send remaining spans
 			sendingThread.join(5000);
 			sendingThread.interrupt();
@@ -423,7 +423,9 @@ public class WavefrontSpanHandler implements Runnable, Closeable {
 	 * the sender thread to stop.
 	 */
 	private static class DeathPill extends SpanToSend {
-		DeathPill() {
+		static final DeathPill INSTANCE = new DeathPill();
+
+		private DeathPill() {
 			super(null, null);
 		}
 	}

--- a/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/test/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandlerTests.java
+++ b/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/test/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandlerTests.java
@@ -24,6 +24,7 @@ import com.wavefront.sdk.common.WavefrontSender;
 import com.wavefront.sdk.common.application.ApplicationTags;
 import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.test.simple.SimpleSpan;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +49,11 @@ class WavefrontSpanHandlerTests {
 	void setUp() {
 		this.sender = mock(WavefrontSender.class);
 		this.sut = new WavefrontSpanHandler(10000, sender, SpanMetrics.NOOP, "source", new ApplicationTags.Builder("application", "service").build(), Collections.emptySet());
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.sut.close();
 	}
 
 	@Test

--- a/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/test/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandlerTests.java
+++ b/micrometer-tracing-reporters/micrometer-tracing-reporter-wavefront/src/test/java/io/micrometer/tracing/reporter/wavefront/WavefrontSpanHandlerTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.tracing.reporter.wavefront;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.UUID;
+
+import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.common.application.ApplicationTags;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.test.simple.SimpleSpan;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link WavefrontSpanHandler}.
+ *
+ * @author Moritz Halbritter
+ */
+class WavefrontSpanHandlerTests {
+	private WavefrontSender sender;
+
+	private WavefrontSpanHandler sut;
+
+	@BeforeEach
+	void setUp() {
+		this.sender = mock(WavefrontSender.class);
+		this.sut = new WavefrontSpanHandler(10000, sender, SpanMetrics.NOOP, "source", new ApplicationTags.Builder("application", "service").build(), Collections.emptySet());
+	}
+
+	@Test
+	void sends() throws Exception {
+		TraceContext traceContext = new DummyTraceContext();
+		SimpleSpan span = new SimpleSpan();
+		sut.end(traceContext, span);
+		sut.close();
+
+		verify(sender).sendSpan(eq("defaultOperation"), anyLong(), anyLong(), eq("source"), eq(UUID.fromString("00000000-0000-0000-7fff-ffffffffffff")), eq(UUID.fromString("00000000-0000-0000-7fff-ffffffffffff")), any(), any(), any(), any());
+	}
+
+	@Test
+	void stopsInTime() {
+		await().pollDelay(Duration.ofMillis(10)).atMost(Duration.ofMillis(100)).until(() -> {
+			sut.close();
+			return true;
+		});
+	}
+
+	static class DummyTraceContext implements TraceContext {
+
+		@Override
+		public String traceId() {
+			return "7fffffffffffffff";
+		}
+
+		@Override
+		public String parentId() {
+			return null;
+		}
+
+		@Override
+		public String spanId() {
+			return "7fffffffffffffff";
+		}
+
+		@Override
+		public Boolean sampled() {
+			return true;
+		}
+	}
+}

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/MeterRegistrySpanMetrics.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/MeterRegistrySpanMetrics.java
@@ -42,9 +42,8 @@ class MeterRegistrySpanMetrics implements SpanMetrics {
     }
 
     @Override
-    public long reportDropped() {
-        spansDropped.increment();
-        return (long) spansDropped.count();
+    public void reportDropped() {
+		spansDropped.increment();
     }
 
     @Override


### PR DESCRIPTION
I suspect there is threading issue in WavefrontSpanHandler. When `close()` is called and there are no spans in the queue, it will block forever on `BlockingQueue#take`. The `close()` method will wait for max 5 seconds. But it won't interrupt the sender thread and just return. This leaks a thread. I improved the code: the `close()` method now returns much more quickly. This is done by inserting a death pill into the span queue. If the reporter thread encounters this death pill, it will stop. Additionally we interrupt the thread after 5 seconds, just to be sure (if e.g. the queue is full when trying to insert the death pill)

I'm sorry that the formatting is off, i couldn't find a `format` task or files which I could import in IntelliJ to fix the formatting.