### PR TITLE
Handlers and contexts for just propagation mechanisms

### DIFF
--- a/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/PropagatingReceiverTracingObservationHandler.java
+++ b/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/PropagatingReceiverTracingObservationHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.tracing.handler;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+
+/**
+ * A {@link TracingObservationHandler} called when receiving occurred - e.g. of messages or http requests.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.0.0
+ */
+public abstract class PropagatingReceiverTracingObservationHandler<T> implements TracingObservationHandler<ReceiverContext<T>> {
+
+    private final Tracer tracer;
+
+    private final Propagator propagator;
+
+    private final Propagator.Getter<T> getter;
+
+    /**
+     * Creates a new instance of {@link PropagatingReceiverTracingObservationHandler}.
+     *
+     * @param tracer     the tracer to use to record events
+     * @param propagator the mechanism to propagate tracing information from the carrier
+     * @param getter     logic used to retrieve tracing information from the carrier
+     */
+    public PropagatingReceiverTracingObservationHandler(Tracer tracer, Propagator propagator, Propagator.Getter<T> getter) {
+        this.tracer = tracer;
+        this.propagator = propagator;
+        this.getter = getter;
+    }
+
+    @Override
+    public void onStart(ReceiverContext<T> context) {
+        Span.Builder extractedSpan = this.propagator.extract(context.getCarrier(), this.getter);
+        getTracingContext(context).setSpan(customizeExtractedSpan(extractedSpan).start());
+    }
+
+    public abstract Span.Builder customizeExtractedSpan(Span.Builder builder);
+
+    @Override
+    public void onError(ReceiverContext<T> context) {
+        context.getError().ifPresent(throwable -> getRequiredSpan(context).error(throwable));
+    }
+
+    @Override
+    public void onStop(ReceiverContext<T> context) {
+        Span span = getRequiredSpan(context);
+        customizeReceiverSpan(span);
+        span.end();
+    }
+
+    public void customizeReceiverSpan(Span span) {
+
+    }
+
+    @Override
+    public Tracer getTracer() {
+        return this.tracer;
+    }
+
+}

--- a/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/PropagatingSenderTracingObservationHandler.java
+++ b/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/PropagatingSenderTracingObservationHandler.java
@@ -31,25 +31,21 @@ public abstract class PropagatingSenderTracingObservationHandler<T> implements T
 
     private final Propagator propagator;
 
-    private final Propagator.Setter<T> setter;
-
     /**
      * Creates a new instance of {@link PropagatingSenderTracingObservationHandler}.
      *
      * @param tracer     the tracer to use to record events
      * @param propagator the mechanism to propagate tracing information into the carrier
-     * @param setter     logic used to inject tracing information to the carrier
      */
-    public PropagatingSenderTracingObservationHandler(Tracer tracer, Propagator propagator, Propagator.Setter<T> setter) {
+    public PropagatingSenderTracingObservationHandler(Tracer tracer, Propagator propagator) {
         this.tracer = tracer;
         this.propagator = propagator;
-        this.setter = setter;
     }
 
     @Override
     public void onStart(SenderContext<T> context) {
         Span childSpan = createSenderSpan(context);
-        this.propagator.inject(childSpan.context(), context.getCarrier(), this.setter);
+        this.propagator.inject(childSpan.context(), context.getCarrier(), context.getSetter());
         getTracingContext(context).setSpan(childSpan);
     }
 
@@ -63,11 +59,17 @@ public abstract class PropagatingSenderTracingObservationHandler<T> implements T
     @Override
     public void onStop(SenderContext<T> context) {
         Span span = getRequiredSpan(context);
-        customizeSenderSpan(span);
+        tagSpan(context, span);
+        customizeSenderSpan(context, span);
         span.end();
     }
 
-    public void customizeSenderSpan(Span span) {
+    /**
+     * Allows to customize the receiver span before reporting it.
+     * @param context context
+     * @param span span to customize
+     */
+    public void customizeSenderSpan(SenderContext<T> context, Span span) {
 
     }
 

--- a/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/PropagatingSenderTracingObservationHandler.java
+++ b/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/PropagatingSenderTracingObservationHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.tracing.handler;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+
+/**
+ * A {@link TracingObservationHandler} called when sending occurred - e.g. of messages or http requests.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.0.0
+ */
+public abstract class PropagatingSenderTracingObservationHandler<T> implements TracingObservationHandler<SenderContext<T>> {
+    private final Tracer tracer;
+
+    private final Propagator propagator;
+
+    private final Propagator.Setter<T> setter;
+
+    /**
+     * Creates a new instance of {@link PropagatingSenderTracingObservationHandler}.
+     *
+     * @param tracer     the tracer to use to record events
+     * @param propagator the mechanism to propagate tracing information into the carrier
+     * @param setter     logic used to inject tracing information to the carrier
+     */
+    public PropagatingSenderTracingObservationHandler(Tracer tracer, Propagator propagator, Propagator.Setter<T> setter) {
+        this.tracer = tracer;
+        this.propagator = propagator;
+        this.setter = setter;
+    }
+
+    @Override
+    public void onStart(SenderContext<T> context) {
+        Span childSpan = createSenderSpan(context);
+        this.propagator.inject(childSpan.context(), context.getCarrier(), this.setter);
+        getTracingContext(context).setSpan(childSpan);
+    }
+
+    public abstract Span createSenderSpan(SenderContext<T> context);
+
+    @Override
+    public void onError(SenderContext<T> context) {
+        context.getError().ifPresent(throwable -> getRequiredSpan(context).error(throwable));
+    }
+
+    @Override
+    public void onStop(SenderContext<T> context) {
+        Span span = getRequiredSpan(context);
+        customizeSenderSpan(span);
+        span.end();
+    }
+
+    public void customizeSenderSpan(Span span) {
+
+    }
+
+    @Override
+    public Tracer getTracer() {
+        return this.tracer;
+    }
+
+}

--- a/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/ReceiverContext.java
+++ b/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/ReceiverContext.java
@@ -17,6 +17,7 @@
 package io.micrometer.tracing.handler;
 
 import io.micrometer.observation.Observation;
+import io.micrometer.tracing.propagation.Propagator;
 
 /**
  * Context used when receiving a message / request over the wire.
@@ -26,7 +27,13 @@ import io.micrometer.observation.Observation;
  */
 public class ReceiverContext<T> extends Observation.Context {
 
+    private final Propagator.Getter<T> getter;
+
     private T carrier;
+
+    public ReceiverContext(Propagator.Getter<T> getter) {
+        this.getter = getter;
+    }
 
     public T getCarrier() {
         return carrier;
@@ -34,5 +41,9 @@ public class ReceiverContext<T> extends Observation.Context {
 
     public void setCarrier(T carrier) {
         this.carrier = carrier;
+    }
+
+    public Propagator.Getter<T> getGetter() {
+        return getter;
     }
 }

--- a/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/ReceiverContext.java
+++ b/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/ReceiverContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.tracing.handler;
+
+import io.micrometer.observation.Observation;
+
+/**
+ * Context used when receiving a message / request over the wire.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.0.0
+ */
+public class ReceiverContext<T> extends Observation.Context {
+
+    private T carrier;
+
+    public T getCarrier() {
+        return carrier;
+    }
+
+    public void setCarrier(T carrier) {
+        this.carrier = carrier;
+    }
+}

--- a/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/SenderContext.java
+++ b/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/SenderContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.tracing.handler;
+
+import io.micrometer.observation.Observation;
+
+/**
+ * Context used when sending a message / request over the wire.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.0.0
+ */
+public class SenderContext<T> extends Observation.Context {
+    private T carrier;
+
+    public T getCarrier() {
+        return carrier;
+    }
+
+    public void setCarrier(T carrier) {
+        this.carrier = carrier;
+    }
+}

--- a/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/SenderContext.java
+++ b/micrometer-tracing-api/src/main/java/io/micrometer/tracing/handler/SenderContext.java
@@ -17,6 +17,7 @@
 package io.micrometer.tracing.handler;
 
 import io.micrometer.observation.Observation;
+import io.micrometer.tracing.propagation.Propagator;
 
 /**
  * Context used when sending a message / request over the wire.
@@ -25,7 +26,13 @@ import io.micrometer.observation.Observation;
  * @since 1.0.0
  */
 public class SenderContext<T> extends Observation.Context {
+    private final Propagator.Setter<T> setter;
+
     private T carrier;
+
+    public SenderContext(Propagator.Setter<T> setter) {
+        this.setter = setter;
+    }
 
     public T getCarrier() {
         return carrier;
@@ -34,4 +41,9 @@ public class SenderContext<T> extends Observation.Context {
     public void setCarrier(T carrier) {
         this.carrier = carrier;
     }
+
+    public Propagator.Setter<T> getSetter() {
+        return setter;
+    }
+
 }


### PR DESCRIPTION
the problem that we're trying to solve is 

- Abstraction over HTTPs, Messagings, RPCs for sending and receiving
- Implementation would know how to inject things into a given carrier (http headers, messaging headers etc.)
- The user implementing the handlers would need to provide some information such as how to create a sender span or how to provide its additional customization

This PR introduces 2 new contexts (temporarily in this repo but would be moved to micrometer)

- `ReceiverContext`
- `SenderContext`

Using one or the other would require setting different span types (PRODUCER, CONSUMER) for messaging and (CLIENT, SERVER) for HTTP.

The new handlers would need to be used to create / customize spans created when sending / receiving information