### PR TITLE
Making Context-Propagation library a mandatory dependency

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,6 +2,8 @@ def VERSIONS = [
 		'javax.servlet:javax.servlet-api:4.0.+',
 		'jakarta.platform:jakarta.jakartaee-web-api:9.1.+',
 
+		'io.micrometer:context-propagation:1.0.0-SNAPSHOT',
+
 		'aopalliance:aopalliance:1.0',
 		// logging
 		'ch.qos.logback:logback-classic:1.2.+',

--- a/micrometer-tracing/build.gradle
+++ b/micrometer-tracing/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
 	api 'io.micrometer:micrometer-observation'
+	api 'io.micrometer:context-propagation'
 	api 'aopalliance:aopalliance'
 
 	// log monitoring


### PR DESCRIPTION
Without this being mandatory things like ObservationThreadLocalAccessor from Micrometer Core will not be applicable

In general without Context Propagation Tracing will not work properly