### PR TITLE
Names spans at stop

### DIFF
--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingReceiverTracingObservationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingReceiverTracingObservationHandler.java
@@ -52,14 +52,13 @@ public class PropagatingReceiverTracingObservationHandler<T extends ReceiverCont
         Span.Builder extractedSpan = this.propagator.extract(context.getCarrier(),
                 (carrier, key) -> context.getGetter().get(carrier, key));
         extractedSpan.kind(Span.Kind.valueOf(context.getKind().name()));
-        String name = context.getContextualName() != null ? context.getContextualName() : context.getName();
-        extractedSpan.name(name);
         getTracingContext(context).setSpan(customizeExtractedSpan(context, extractedSpan).start());
     }
 
     /**
      * Customizes the extracted span (e.g. you can set the {@link Span.Kind} via
      * {@link Span.Builder#kind(Span.Kind)}).
+     * @param context context
      * @param builder span builder
      * @return span builder
      */
@@ -77,6 +76,7 @@ public class PropagatingReceiverTracingObservationHandler<T extends ReceiverCont
         Span span = getRequiredSpan(context);
         tagSpan(context, span);
         customizeReceiverSpan(context, span);
+        span.name(getSpanName(context));
         span.end();
     }
 

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingSenderTracingObservationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingSenderTracingObservationHandler.java
@@ -66,11 +66,10 @@ public class PropagatingSenderTracingObservationHandler<T extends SenderContext>
         if (parentSpan != null) {
             builder = builder.setParent(parentSpan.context());
         }
-        String name = context.getContextualName() != null ? context.getContextualName() : context.getName();
         if (context.getRemoteServiceName() != null) {
             builder = builder.remoteServiceName(context.getRemoteServiceName());
         }
-        return builder.name(name).start();
+        return builder.start();
     }
 
     @Override
@@ -83,6 +82,7 @@ public class PropagatingSenderTracingObservationHandler<T extends SenderContext>
         Span span = getRequiredSpan(context);
         tagSpan(context, span);
         customizeSenderSpan(context, span);
+        span.name(getSpanName(context));
         span.end();
     }
 


### PR DESCRIPTION
Without this change the contextual name for spans is resolved too early and typically it's `null`.
With this change we're setting the span name almost at the end where all components required to name the span should have already been set