### PR TITLE
Add sub interfaces to denote brave/otel based BuildingBulocks

### DIFF
--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/BuildingBlocks.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/BuildingBlocks.java
@@ -73,4 +73,18 @@ public interface BuildingBlocks {
      */
     List<FinishedSpan> getFinishedSpans();
 
+    /**
+     * Sub interface for Brave based {@link BuildingBlocks}.
+     */
+    interface BraveBuildingBlocks extends BuildingBlocks {
+
+    }
+
+    /**
+     * Sub interface for OTel based {@link BuildingBlocks}.
+     */
+    interface OtelBuildingBlocks extends BuildingBlocks {
+
+    }
+
 }

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/inmemory/InMemoryBraveSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/inmemory/InMemoryBraveSetup.java
@@ -111,7 +111,7 @@ public final class InMemoryBraveSetup implements AutoCloseable {
         /**
          * All Brave building blocks.
          */
-        public static class BraveBuildingBlocks implements BuildingBlocks {
+        public static class BraveBuildingBlocks implements BuildingBlocks.BraveBuildingBlocks {
 
             private final Tracing tracing;
 

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/inmemory/InMemoryOtelSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/inmemory/InMemoryOtelSetup.java
@@ -122,7 +122,7 @@ public final class InMemoryOtelSetup implements AutoCloseable {
         /**
          * All OTel building blocks required to communicate with Zipkin.
          */
-        public static class OtelBuildingBlocks implements BuildingBlocks {
+        public static class OtelBuildingBlocks implements BuildingBlocks.OtelBuildingBlocks {
 
             private final SdkTracerProvider sdkTracerProvider;
 

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/WavefrontBraveSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/WavefrontBraveSetup.java
@@ -143,7 +143,7 @@ public final class WavefrontBraveSetup implements AutoCloseable {
          * All Brave building blocks required to communicate with Zipkin.
          */
         @SuppressWarnings("rawtypes")
-        public static class BraveBuildingBlocks implements BuildingBlocks {
+        public static class BraveBuildingBlocks implements BuildingBlocks.BraveBuildingBlocks {
 
             private final WavefrontSpanHandler wavefrontSpanHandler;
 

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/WavefrontOtelSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/WavefrontOtelSetup.java
@@ -153,7 +153,7 @@ public final class WavefrontOtelSetup implements AutoCloseable {
          * All OTel building blocks required to communicate with Zipkin.
          */
         @SuppressWarnings("rawtypes")
-        public static class OtelBuildingBlocks implements BuildingBlocks {
+        public static class OtelBuildingBlocks implements BuildingBlocks.OtelBuildingBlocks {
 
             private final WavefrontOtelSpanHandler wavefrontOTelSpanHandler;
 

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinBraveSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinBraveSetup.java
@@ -124,7 +124,7 @@ public final class ZipkinBraveSetup implements AutoCloseable {
         /**
          * All Brave building blocks required to communicate with Zipkin.
          */
-        public static class BraveBuildingBlocks implements BuildingBlocks {
+        public static class BraveBuildingBlocks implements BuildingBlocks.BraveBuildingBlocks {
 
             private final Sender sender;
 

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinOtelSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinOtelSetup.java
@@ -134,7 +134,7 @@ public final class ZipkinOtelSetup implements AutoCloseable {
         /**
          * All OTel building blocks required to communicate with Zipkin.
          */
-        public static class OtelBuildingBlocks implements BuildingBlocks {
+        public static class OtelBuildingBlocks implements BuildingBlocks.OtelBuildingBlocks {
 
             private final Sender sender;
 


### PR DESCRIPTION
While testing failed observation case with `SampleTestRunner`, Brave and OTel have different error handling for spans.
To verify the spans in test, I need to differentiate the check for Brave and OTel based test run.

To detect the current test run, whether Brave or OTel, I need to have if check like this:
```java
protected boolean isBrave(BuildingBlocks bb) {
	return bb instanceof InMemoryBraveSetup.Builder.BraveBuildingBlocks
			|| bb instanceof ZipkinBraveSetup.Builder.BraveBuildingBlocks
			|| bb instanceof WavefrontBraveSetup.Builder.BraveBuildingBlocks;
}
```

This PR adds a marker/sub interface to indicate the `BuildingBlocks` implementation is based on the Brave or OTel.

With the change, the above `isBrave` method can be written as:

```java
protected boolean isBrave(BuildingBlocks bb) {
	return bb instanceof BuildingBlocks.BraveBuildingBlocks;
}
```
```

