### PR TITLE
Sets an error status on OTel span when recording an exception

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
@@ -16,12 +16,13 @@
 
 package io.micrometer.tracing.otel.bridge;
 
+import io.micrometer.tracing.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
-import io.micrometer.tracing.Span;
-import io.opentelemetry.context.Context;
 
 /**
  * OpenTelemetry implementation of a {@link Span}.
@@ -121,6 +122,7 @@ class OtelSpan implements Span {
     @Override
     public Span error(Throwable throwable) {
         this.delegate.recordException(throwable);
+        this.delegate.setStatus(StatusCode.ERROR, throwable.getMessage());
         return new OtelSpan(this.delegate);
     }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelSpanTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelSpanTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.tracing.otel.bridge;
+
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class OtelSpanTests {
+
+    @Test
+    void should_set_status_to_error_when_recording_exception() {
+        ArrayListSpanProcessor arrayListSpanProcessor = new ArrayListSpanProcessor();
+        SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+                .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())
+                .addSpanProcessor(arrayListSpanProcessor).build();
+        OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder().setTracerProvider(sdkTracerProvider)
+                .setPropagators(ContextPropagators.create(B3Propagator.injectingSingleHeader())).build();
+        io.opentelemetry.api.trace.Tracer otelTracer = openTelemetrySdk.getTracer("io.micrometer.micrometer-tracing");
+        OtelSpan otelSpan = new OtelSpan(otelTracer.spanBuilder("foo").startSpan());
+
+        otelSpan.error(new RuntimeException("boom!")).end();
+
+        SpanData poll = arrayListSpanProcessor.spans().poll();
+        then(poll.getStatus()).isEqualTo(StatusData.create(StatusCode.ERROR, "boom!"));
+        then(poll.getEvents()).hasSize(1);
+        then(poll.getEvents().get(0).getAttributes().asMap().values()).containsAnyOf("boom!");
+    }
+
+}


### PR DESCRIPTION
without this change the spans in zipkin that should contain error are not highlighted in red
with this change whenever an OTel span has an exception added then we automatically modify its status to error