### PR TITLE
Add event handlings to "Propagating[Sender|Receiver]TracingObservatinnHandler"

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/handler/PropagatingReceiverTracingObservationHandlerBraveTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/handler/PropagatingReceiverTracingObservationHandlerBraveTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.tracing.brave.handler;
+
+import brave.Tracing;
+import brave.handler.MutableSpan;
+import brave.test.TestSpanHandler;
+import io.micrometer.observation.Observation.Event;
+import io.micrometer.observation.transport.ReceiverContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
+import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
+import io.micrometer.tracing.brave.bridge.BravePropagator;
+import io.micrometer.tracing.brave.bridge.BraveTracer;
+import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@SuppressWarnings("unchecked")
+class PropagatingReceiverTracingObservationHandlerBraveTests {
+
+    TestSpanHandler testSpanHandler = new TestSpanHandler();
+
+    Tracing tracing = Tracing.newBuilder().addSpanHandler(testSpanHandler).build();
+
+    Tracer tracer = new BraveTracer(tracing.tracer(), new BraveCurrentTraceContext(tracing.currentTraceContext()),
+            new BraveBaggageManager());
+
+    PropagatingReceiverTracingObservationHandler<ReceiverContext<?>> handler = new PropagatingReceiverTracingObservationHandler<>(
+            tracer, new BravePropagator(tracing));
+
+    @Test
+    void should_be_applicable_for_non_null_context() {
+        then(handler.supportsContext(new ReceiverContext<>((carrier, key) -> null))).isTrue();
+    }
+
+    @Test
+    void should_not_be_applicable_for_null_context() {
+        then(handler.supportsContext(null)).isFalse();
+    }
+
+    @Test
+    void should_signal_events() {
+        Event event = Event.of("foo", "bar");
+        ReceiverContext<Object> receiverContext = new ReceiverContext<>((carrier, key) -> "val");
+        receiverContext.setCarrier(new Object());
+        receiverContext.setName("foo");
+
+        handler.onStart(receiverContext);
+        handler.onEvent(event, receiverContext);
+        handler.onStop(receiverContext);
+
+        MutableSpan data = takeOnlySpan();
+        then(data.annotations()).hasSize(1);
+        then(data.annotations().stream().findFirst()).isPresent().get().extracting(Map.Entry::getValue).isSameAs("bar");
+    }
+
+    private MutableSpan takeOnlySpan() {
+        List<MutableSpan> spans = testSpanHandler.spans();
+        then(spans).hasSize(1);
+        MutableSpan mutableSpan = spans.get(0);
+        return mutableSpan;
+    }
+
+}

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/handler/PropagatingReceiverTracingObservationHandlerOtelTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/handler/PropagatingReceiverTracingObservationHandlerOtelTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.otel.handler;
+
+import io.micrometer.observation.Observation.Event;
+import io.micrometer.observation.transport.ReceiverContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
+import io.micrometer.tracing.otel.bridge.*;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Queue;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class PropagatingReceiverTracingObservationHandlerOtelTests {
+
+    ArrayListSpanProcessor testSpanProcessor = new ArrayListSpanProcessor();
+
+    SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+            .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())
+            .addSpanProcessor(SimpleSpanProcessor.create(testSpanProcessor)).build();
+
+    OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder().setTracerProvider(sdkTracerProvider)
+            .setPropagators(ContextPropagators.create(B3Propagator.injectingSingleHeader())).build();
+
+    io.opentelemetry.api.trace.Tracer otelTracer = openTelemetrySdk.getTracer("io.micrometer.micrometer-tracing");
+
+    Tracer tracer = new OtelTracer(otelTracer, new OtelCurrentTraceContext(), event -> {
+    }, new OtelBaggageManager(new OtelCurrentTraceContext(), Collections.emptyList(), Collections.emptyList()));
+
+    PropagatingReceiverTracingObservationHandler<ReceiverContext<?>> handler = new PropagatingReceiverTracingObservationHandler<>(
+            tracer, new OtelPropagator(ContextPropagators.noop(), otelTracer));
+
+    @Test
+    void should_signal_events() {
+        Event event = Event.of("foo", "bar");
+        ReceiverContext<Object> receiverContext = new ReceiverContext<>((carrier, key) -> "val");
+        receiverContext.setCarrier(new Object());
+        receiverContext.setName("foo");
+
+        handler.onStart(receiverContext);
+        handler.onEvent(event, receiverContext);
+        handler.onStop(receiverContext);
+
+        SpanData data = takeOnlySpan();
+        then(data.getEvents()).hasSize(1).element(0).extracting(EventData::getName).isEqualTo("bar");
+    }
+
+    private SpanData takeOnlySpan() {
+        Queue<SpanData> spans = testSpanProcessor.spans();
+        then(spans).hasSize(1);
+        return testSpanProcessor.takeLocalSpan();
+    }
+
+}

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingReceiverTracingObservationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingReceiverTracingObservationHandler.java
@@ -17,6 +17,7 @@
 package io.micrometer.tracing.handler;
 
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Event;
 import io.micrometer.observation.transport.ReceiverContext;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
@@ -64,6 +65,11 @@ public class PropagatingReceiverTracingObservationHandler<T extends ReceiverCont
      */
     public Span.Builder customizeExtractedSpan(T context, Span.Builder builder) {
         return builder;
+    }
+
+    @Override
+    public void onEvent(Event event, T context) {
+        getTracingContext(context).getSpan().event(event.getContextualName());
     }
 
     @Override

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingSenderTracingObservationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingSenderTracingObservationHandler.java
@@ -17,6 +17,7 @@
 package io.micrometer.tracing.handler;
 
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Event;
 import io.micrometer.observation.transport.SenderContext;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
@@ -75,6 +76,11 @@ public class PropagatingSenderTracingObservationHandler<T extends SenderContext>
     @Override
     public void onError(T context) {
         context.getError().ifPresent(throwable -> getRequiredSpan(context).error(throwable));
+    }
+
+    @Override
+    public void onEvent(Event event, T context) {
+        getTracingContext(context).getSpan().event(event.getContextualName());
     }
 
     @Override


### PR DESCRIPTION
`Propagating[Sender|Receiver]TracingObservatinnHandler` were not populating events due to the missing `onEvent()` implementation.
This PR adds the method impl.