### PR TITLE
Use epoch milli to check span start/stop

### DIFF
--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleTracer.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleTracer.java
@@ -59,8 +59,8 @@ public class SimpleTracer implements Tracer {
     public SimpleSpan onlySpan() {
         assertTrue(this.spans.size() == 1, "There must be only one span");
         SimpleSpan span = this.spans.getFirst();
-        assertTrue(span.getStartTimestamp().getNano() > 0, "Span must be started");
-        assertTrue(span.getEndTimestamp().getNano() > 0, "Span must be finished");
+        assertTrue(span.getStartTimestamp().toEpochMilli() > 0, "Span must be started");
+        assertTrue(span.getEndTimestamp().toEpochMilli() > 0, "Span must be finished");
         return span;
     }
 
@@ -79,7 +79,7 @@ public class SimpleTracer implements Tracer {
     public SimpleSpan lastSpan() {
         assertTrue(!this.spans.isEmpty(), "There must be at least one span");
         SimpleSpan span = this.spans.getLast();
-        assertTrue(span.getStartTimestamp().getNano() > 0, "Span must be started");
+        assertTrue(span.getStartTimestamp().toEpochMilli() > 0, "Span must be started");
         return span;
     }
 

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SpanAssert.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SpanAssert.java
@@ -316,7 +316,7 @@ public class SpanAssert<SELF extends SpanAssert<SELF>> extends AbstractAssert<SE
      */
     public SELF isEnded() {
         isNotNull();
-        if (this.actual.getEndTimestamp().getEpochSecond() == 0) {
+        if (this.actual.getEndTimestamp().toEpochMilli() == 0) {
             failWithMessage("Span should be ended");
         }
         return (SELF) this;
@@ -337,7 +337,7 @@ public class SpanAssert<SELF extends SpanAssert<SELF>> extends AbstractAssert<SE
      */
     public SELF isNotEnded() {
         isNotNull();
-        if (this.actual.getEndTimestamp().getEpochSecond() != 0) {
+        if (this.actual.getEndTimestamp().toEpochMilli() != 0) {
             failWithMessage("Span should not be ended");
         }
         return (SELF) this;


### PR DESCRIPTION
Prior to this change, `TracerAssert#onlySpan` randomly failed.

This was because it had followings to check a span has started/stopped.

```java
assertTrue(span.getStartTimestamp().getNano() > 0, "Span must be started");
assertTrue(span.getEndTimestamp().getNano() > 0, "Span must be finished");
```

The `getNano()` could return `0` for valid `Instant`.

For example:
```java
Instant i = Instant.parse("2022-09-07T00:33:58Z");
assertThat(i.getNano()).isEqualTo(0);

i = Instant.ofEpochMilli(1662510838000L);
assertThat(i.getNano()).isEqualTo(0);
```

Instead of using `getNano()`, this PR changes to constantly use `toEpochMilli() > 0` to check whether the span has started or stopped.

`Instant.ofEpochMilli(0).toEpochMilli()` returns `0` whereas `Instant.ofEpochMilli(10).toEpochMilli()` returns `10`.


