### PR TITLE
Implement "onEvent()" as a TracingObservationHandler default method

### DIFF
--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/DefaultTracingObservationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/DefaultTracingObservationHandler.java
@@ -61,11 +61,6 @@ public class DefaultTracingObservationHandler implements TracingObservationHandl
     }
 
     @Override
-    public void onEvent(Observation.Event event, Observation.Context context) {
-        getTracingContext(context).getSpan().event(event.getContextualName());
-    }
-
-    @Override
     public Tracer getTracer() {
         return this.tracer;
     }

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingReceiverTracingObservationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingReceiverTracingObservationHandler.java
@@ -17,7 +17,6 @@
 package io.micrometer.tracing.handler;
 
 import io.micrometer.observation.Observation;
-import io.micrometer.observation.Observation.Event;
 import io.micrometer.observation.transport.ReceiverContext;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
@@ -65,11 +64,6 @@ public class PropagatingReceiverTracingObservationHandler<T extends ReceiverCont
      */
     public Span.Builder customizeExtractedSpan(T context, Span.Builder builder) {
         return builder;
-    }
-
-    @Override
-    public void onEvent(Event event, T context) {
-        getTracingContext(context).getSpan().event(event.getContextualName());
     }
 
     @Override

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingSenderTracingObservationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/PropagatingSenderTracingObservationHandler.java
@@ -17,7 +17,6 @@
 package io.micrometer.tracing.handler;
 
 import io.micrometer.observation.Observation;
-import io.micrometer.observation.Observation.Event;
 import io.micrometer.observation.transport.SenderContext;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
@@ -76,11 +75,6 @@ public class PropagatingSenderTracingObservationHandler<T extends SenderContext>
     @Override
     public void onError(T context) {
         context.getError().ifPresent(throwable -> getRequiredSpan(context).error(throwable));
-    }
-
-    @Override
-    public void onEvent(Event event, T context) {
-        getTracingContext(context).getSpan().event(event.getContextualName());
     }
 
     @Override

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/TracingObservationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/TracingObservationHandler.java
@@ -21,6 +21,7 @@ import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Event;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.tracing.CurrentTraceContext;
 import io.micrometer.tracing.Span;
@@ -78,6 +79,11 @@ public interface TracingObservationHandler<T extends Observation.Context> extend
         }
         CurrentTraceContext.Scope scope = getTracer().currentTraceContext().maybeScope(span.context());
         getTracingContext(context).setSpanAndScope(span, scope);
+    }
+
+    @Override
+    default void onEvent(Event event, T context) {
+        getTracingContext(context).getSpan().event(event.getContextualName());
     }
 
     @Override


### PR DESCRIPTION
Move up the `onEvent()` implementation to the `TracingObservationHandler`'s default method.