### PR TITLE
Fixes invalid Baggage propagation for W3C with Brave

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/build.gradle
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/build.gradle
@@ -21,5 +21,6 @@ dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter'
 	testImplementation 'org.assertj:assertj-core'
 	testImplementation 'io.zipkin.brave:brave-instrumentation-http-tests'
+	testImplementation 'ch.qos.logback:logback-classic'
 }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageFields.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageFields.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.tracing.brave.bridge;
+
+import io.micrometer.tracing.BaggageInScope;
+
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Objects;
+
+class BraveBaggageFields {
+
+    private final List<AbstractMap.SimpleEntry<BaggageInScope, String>> entries;
+
+    BraveBaggageFields(List<AbstractMap.SimpleEntry<BaggageInScope, String>> entries) {
+        this.entries = entries;
+    }
+
+    List<AbstractMap.SimpleEntry<BaggageInScope, String>> getEntries() {
+        return entries;
+    }
+
+    @Override
+    public String toString() {
+        return "BraveBaggageFields{" + "entries=" + entries + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BraveBaggageFields that = (BraveBaggageFields) o;
+        return Objects.equals(entries, that.entries);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entries);
+    }
+
+}

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BravePropagator.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BravePropagator.java
@@ -66,6 +66,9 @@ public class BravePropagator implements Propagator {
     }
 
     private void updateExistingBaggageFieldsWithUpdatedValues(TraceContextOrSamplingFlags extract) {
+        if (extract.context() == null) {
+            return;
+        }
         List<Object> extra = extract.context().extra();
         extra.stream().filter(BraveBaggageFields.class::isInstance).forEach(o -> {
             BraveBaggageFields fields = (BraveBaggageFields) o;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BravePropagator.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BravePropagator.java
@@ -16,14 +16,16 @@
 
 package io.micrometer.tracing.brave.bridge;
 
-import java.util.List;
-
 import brave.Tracing;
+import brave.baggage.BaggageField;
+import brave.internal.baggage.BaggageFields;
 import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContextOrSamplingFlags;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.propagation.Propagator;
+
+import java.util.List;
 
 /**
  * Brave implementation of a {@link Propagator}.
@@ -59,7 +61,25 @@ public class BravePropagator implements Propagator {
         if (extract.samplingFlags() == SamplingFlags.EMPTY) {
             return new BraveSpanBuilder(this.tracing.tracer());
         }
+        updateExistingBaggageFieldsWithUpdatedValues(extract);
         return BraveSpanBuilder.toBuilder(this.tracing.tracer(), extract);
+    }
+
+    private void updateExistingBaggageFieldsWithUpdatedValues(TraceContextOrSamplingFlags extract) {
+        List<Object> extra = extract.context().extra();
+        extra.stream().filter(BraveBaggageFields.class::isInstance).forEach(o -> {
+            BraveBaggageFields fields = (BraveBaggageFields) o;
+            extra.stream().filter(BaggageFields.class::isInstance).forEach(bf -> {
+                BaggageFields baggageFields = (BaggageFields) bf;
+                List<BaggageField> allFields = baggageFields.getAllFields();
+                fields.getEntries().forEach(e -> {
+                    String key = e.getKey().name();
+                    String value = e.getValue();
+                    allFields.stream().filter(allField -> allField.name().equals(key))
+                            .forEach(allField -> allField.updateValue(extract, value));
+                });
+            });
+        });
     }
 
 }


### PR DESCRIPTION
without this change we've managed to successfully parse the request and create baggage entries, however they got then lost when new scopes were opened with this change we're using the native Brave mechanism for BaggageField creation however we're updating the existing BaggageFields values when using the BravePropagator