### PR TITLE
Adding a NoOp BaggageManager and allowing its usage in Tracers

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTracer.java
@@ -16,16 +16,10 @@
 
 package io.micrometer.tracing.brave.bridge;
 
-import java.util.Map;
-
 import brave.propagation.TraceContextOrSamplingFlags;
-import io.micrometer.tracing.BaggageInScope;
-import io.micrometer.tracing.CurrentTraceContext;
-import io.micrometer.tracing.ScopedSpan;
-import io.micrometer.tracing.Span;
-import io.micrometer.tracing.SpanCustomizer;
-import io.micrometer.tracing.TraceContext;
-import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.*;
+
+import java.util.Map;
 
 /**
  * Brave implementation of a {@link Tracer}.
@@ -37,7 +31,7 @@ public class BraveTracer implements Tracer {
 
     private final brave.Tracer tracer;
 
-    private final BraveBaggageManager braveBaggageManager;
+    private final BaggageManager braveBaggageManager;
 
     private final CurrentTraceContext currentTraceContext;
 
@@ -47,10 +41,19 @@ public class BraveTracer implements Tracer {
      * @param context Brave context
      * @param braveBaggageManager Brave baggage manager
      */
-    public BraveTracer(brave.Tracer tracer, CurrentTraceContext context, BraveBaggageManager braveBaggageManager) {
+    public BraveTracer(brave.Tracer tracer, CurrentTraceContext context, BaggageManager braveBaggageManager) {
         this.tracer = tracer;
         this.braveBaggageManager = braveBaggageManager;
         this.currentTraceContext = context;
+    }
+
+    /**
+     * Creates a new instance of {@link BraveTracer} with no baggage support.
+     * @param tracer Brave Tracer
+     * @param context Brave context
+     */
+    public BraveTracer(brave.Tracer tracer, CurrentTraceContext context) {
+        this(tracer, context, NOOP);
     }
 
     @Override

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/W3CPropagation.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/W3CPropagation.java
@@ -26,6 +26,7 @@ import io.micrometer.common.util.StringUtils;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.tracing.BaggageInScope;
+import io.micrometer.tracing.BaggageManager;
 import io.micrometer.tracing.internal.EncodingUtils;
 
 import java.util.*;
@@ -99,16 +100,16 @@ public class W3CPropagation extends Propagation.Factory implements Propagation<S
     private final W3CBaggagePropagator baggagePropagator;
 
     @Nullable
-    private final BraveBaggageManager braveBaggageManager;
+    private final BaggageManager braveBaggageManager;
 
     /**
      * Creates an instance of {@link W3CPropagation} with baggage support.
-     * @param braveBaggageManager Brave baggage manager
+     * @param baggageManager baggage manager
      * @param localFields local fields to be registered as baggage
      */
-    public W3CPropagation(BraveBaggageManager braveBaggageManager, List<String> localFields) {
-        this.baggagePropagator = new W3CBaggagePropagator(braveBaggageManager, localFields);
-        this.braveBaggageManager = braveBaggageManager;
+    public W3CPropagation(BaggageManager baggageManager, List<String> localFields) {
+        this.baggagePropagator = new W3CBaggagePropagator(baggageManager, localFields);
+        this.braveBaggageManager = baggageManager;
     }
 
     /**
@@ -318,12 +319,12 @@ class W3CBaggagePropagator {
 
     private static final List<String> FIELDS = singletonList(FIELD);
 
-    private final BraveBaggageManager braveBaggageManager;
+    private final BaggageManager braveBaggageManager;
 
     private final List<String> localFields;
 
-    W3CBaggagePropagator(BraveBaggageManager braveBaggageManager, List<String> localFields) {
-        this.braveBaggageManager = braveBaggageManager;
+    W3CBaggagePropagator(BaggageManager baggageManager, List<String> localFields) {
+        this.braveBaggageManager = baggageManager;
         this.localFields = localFields;
     }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
@@ -16,16 +16,9 @@
 
 package io.micrometer.tracing.otel.bridge;
 
-import java.util.Map;
+import io.micrometer.tracing.*;
 
-import io.micrometer.tracing.BaggageInScope;
-import io.micrometer.tracing.BaggageManager;
-import io.micrometer.tracing.CurrentTraceContext;
-import io.micrometer.tracing.ScopedSpan;
-import io.micrometer.tracing.Span;
-import io.micrometer.tracing.SpanCustomizer;
-import io.micrometer.tracing.TraceContext;
-import io.micrometer.tracing.Tracer;
+import java.util.Map;
 
 /**
  * OpenTelemetry implementation of a {@link Tracer}.
@@ -56,6 +49,17 @@ public class OtelTracer implements Tracer {
         this.publisher = publisher;
         this.otelBaggageManager = otelBaggageManager;
         this.otelCurrentTraceContext = otelCurrentTraceContext;
+    }
+
+    /**
+     * Creates a new instance of {@link OtelTracer} with no baggage support.
+     * @param tracer tracer
+     * @param otelCurrentTraceContext current trace context
+     * @param publisher event publisher
+     */
+    public OtelTracer(io.opentelemetry.api.trace.Tracer tracer, OtelCurrentTraceContext otelCurrentTraceContext,
+            EventPublisher publisher) {
+        this(tracer, otelCurrentTraceContext, publisher, NOOP);
     }
 
     @Override

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/BaggageInScope.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/BaggageInScope.java
@@ -16,9 +16,9 @@
 
 package io.micrometer.tracing;
 
-import java.io.Closeable;
-
 import io.micrometer.common.lang.Nullable;
+
+import java.io.Closeable;
 
 /**
  * Inspired by OpenZipkin Brave's {@code BaggageField}. Since some tracer implementations
@@ -33,6 +33,46 @@ import io.micrometer.common.lang.Nullable;
  * @since 1.0.0
  */
 public interface BaggageInScope extends Closeable {
+
+    /**
+     * A noop implementation.
+     */
+    BaggageInScope NOOP = new BaggageInScope() {
+        @Override
+        public String name() {
+            return null;
+        }
+
+        @Override
+        public String get() {
+            return null;
+        }
+
+        @Override
+        public String get(TraceContext traceContext) {
+            return null;
+        }
+
+        @Override
+        public BaggageInScope set(String value) {
+            return this;
+        }
+
+        @Override
+        public BaggageInScope set(TraceContext traceContext, String value) {
+            return this;
+        }
+
+        @Override
+        public BaggageInScope makeCurrent() {
+            return this;
+        }
+
+        @Override
+        public void close() {
+
+        }
+    };
 
     /**
      * @return name of the baggage entry

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/BaggageManager.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/BaggageManager.java
@@ -16,9 +16,10 @@
 
 package io.micrometer.tracing;
 
-import java.util.Map;
-
 import io.micrometer.common.lang.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Manages {@link BaggageInScope} entries. Upon retrieval / creation of a baggage entry
@@ -29,6 +30,36 @@ import io.micrometer.common.lang.Nullable;
  * @since 1.0.0
  */
 public interface BaggageManager {
+
+    /**
+     * A noop implementation.
+     */
+    BaggageManager NOOP = new BaggageManager() {
+        @Override
+        public Map<String, String> getAllBaggage() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public BaggageInScope getBaggage(String name) {
+            return BaggageInScope.NOOP;
+        }
+
+        @Override
+        public BaggageInScope getBaggage(TraceContext traceContext, String name) {
+            return BaggageInScope.NOOP;
+        }
+
+        @Override
+        public BaggageInScope createBaggage(String name) {
+            return BaggageInScope.NOOP;
+        }
+
+        @Override
+        public BaggageInScope createBaggage(String name, String value) {
+            return BaggageInScope.NOOP;
+        }
+    };
 
     /**
      * @return mapping of all baggage entries from the given scope


### PR DESCRIPTION
without this change BaggageManager is mandatory even if you're not using it with this change you can create a tracer with a NoOpBaggageManager