### PR TITLE
Span required for event

### DIFF
--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/TracingObservationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/TracingObservationHandler.java
@@ -84,7 +84,7 @@ public interface TracingObservationHandler<T extends Observation.Context> extend
 
     @Override
     default void onEvent(Event event, T context) {
-        getTracingContext(context).getSpan().event(event.getContextualName());
+        getRequiredSpan(context).event(event.getContextualName());
     }
 
     @Override

--- a/micrometer-tracing/src/test/java/io/micrometer/tracing/handler/TracingObservationHandlerTests.java
+++ b/micrometer-tracing/src/test/java/io/micrometer/tracing/handler/TracingObservationHandlerTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.handler;
+
+import io.micrometer.observation.Observation;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+
+class TracingObservationHandlerTests {
+
+    @Test
+    void iseShouldBeCalledWhenNoSpanInContext() {
+        TracingObservationHandler<Observation.Context> handler = () -> null;
+
+        thenThrownBy(() -> handler.onEvent(() -> "", new Observation.Context()))
+                .isInstanceOf(IllegalStateException.class).hasMessageContaining("Span wasn't started");
+    }
+
+}


### PR DESCRIPTION
without this change if there's no span we will throw an npe when an event gets marked on an observation 

with this change we're requiring a span to be there, otherwise we will throw a dedicated exception