### PR TITLE
Exclude boms in micrometer-tracing-bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,16 @@ subprojects {
 				nebula(MavenPublication) {
 					// Nebula converts dynamic versions to static ones so it's ok.
 					suppressAllPomMetadataWarnings()
+
+					if (project.name == 'micrometer-tracing-bom') {
+						pom.withXml {
+							asNode().dependencyManagement.dependencies.dependency.each {
+								if (!it.artifactId.text().equals("micrometer-bom") && it.type.text().equals("pom")) {
+									it.parent().remove(it)
+								}
+							}
+						}
+					}
 				}
 			}
 			repositories {


### PR DESCRIPTION
Exclude any boms other than micrometer-bom in micrometer-tracing-bom's pom.xml.

This change removed `brave-bom`, `opentelemetry-bom`, `opentelemetry-bom-alpha`, `junit-bom` and left `micrometer-bom` in the generated bom. 

Fixes #79