### PR TITLE
Sets ThreadLocalCurrentTraceContext as default for Brave Tracing in SampleTestRunner

### DIFF
--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/inmemory/InMemoryBraveSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/inmemory/InMemoryBraveSetup.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import brave.test.TestSpanHandler;
 import io.micrometer.observation.Observation;
@@ -316,7 +317,8 @@ public final class InMemoryBraveSetup implements AutoCloseable {
 
         private static Tracing tracing(TestSpanHandler testSpanHandler, String applicationName) {
             return Tracing.newBuilder().localServiceName(applicationName).addSpanHandler(testSpanHandler)
-                    .sampler(Sampler.ALWAYS_SAMPLE).build();
+                    .currentTraceContext(ThreadLocalCurrentTraceContext.create()).sampler(Sampler.ALWAYS_SAMPLE)
+                    .build();
         }
 
         private static HttpTracing httpTracing(Tracing tracing) {

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/WavefrontBraveSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/WavefrontBraveSetup.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import brave.Tracing;
 import brave.handler.SpanHandler;
 import brave.http.HttpTracing;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import brave.test.TestSpanHandler;
 import com.wavefront.sdk.common.application.ApplicationTags;
@@ -404,7 +405,8 @@ public final class WavefrontBraveSetup implements AutoCloseable {
 
         private static Tracing tracing(SpanHandler spanHandler, TestSpanHandler testSpanHandler) {
             return Tracing.newBuilder().traceId128Bit(true).addSpanHandler(spanHandler).addSpanHandler(testSpanHandler)
-                    .sampler(Sampler.ALWAYS_SAMPLE).build();
+                    .currentTraceContext(ThreadLocalCurrentTraceContext.create()).sampler(Sampler.ALWAYS_SAMPLE)
+                    .build();
         }
 
         private static HttpTracing httpTracing(Tracing tracing) {

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinBraveSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinBraveSetup.java
@@ -16,30 +16,16 @@
 
 package io.micrometer.tracing.test.reporter.zipkin;
 
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
 import brave.Tracing;
 import brave.http.HttpTracing;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import brave.test.TestSpanHandler;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
-import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
-import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
-import io.micrometer.tracing.brave.bridge.BraveFinishedSpan;
-import io.micrometer.tracing.brave.bridge.BraveHttpClientHandler;
-import io.micrometer.tracing.brave.bridge.BraveHttpServerHandler;
-import io.micrometer.tracing.brave.bridge.BravePropagator;
-import io.micrometer.tracing.brave.bridge.BraveTracer;
+import io.micrometer.tracing.brave.bridge.*;
 import io.micrometer.tracing.exporter.FinishedSpan;
 import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
 import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
@@ -54,6 +40,15 @@ import zipkin2.reporter.Reporter;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.brave.ZipkinSpanHandler;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Provides Zipkin setup with Brave.
@@ -392,7 +387,8 @@ public final class ZipkinBraveSetup implements AutoCloseable {
                 String applicationName) {
             return Tracing.newBuilder().localServiceName(applicationName)
                     .addSpanHandler(ZipkinSpanHandler.newBuilder(reporter).build()).addSpanHandler(testSpanHandler)
-                    .sampler(Sampler.ALWAYS_SAMPLE).build();
+                    .currentTraceContext(ThreadLocalCurrentTraceContext.create()).sampler(Sampler.ALWAYS_SAMPLE)
+                    .build();
         }
 
         private static HttpTracing httpTracing(Tracing tracing) {


### PR DESCRIPTION
without this change by default an InheratibleThreadLocal for CurrentTraceContext is being used by Brave with SampleTestRunner

with this change we're setting the default to be just ThreadLocal for CurrentTraceContext