### PR TITLE
Adds appending of baggage entries from parent context

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/propagation/BaggageTextMapPropagator.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/propagation/BaggageTextMapPropagator.java
@@ -33,7 +33,9 @@ import java.util.stream.Collectors;
 
 /**
  * {@link TextMapPropagator} that adds compatible baggage entries (name of the field means
- * an HTTP header entry).
+ * an HTTP header entry). If existing baggage is present in the context, this will append
+ * entries to the existing one. Preferably this {@link TextMapPropagator} should be added
+ * as last.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
@@ -87,6 +89,8 @@ public class BaggageTextMapPropagator implements TextMapPropagator {
         BaggageBuilder builder = Baggage.current().toBuilder();
         baggageEntries
                 .forEach((key, value) -> builder.put(key, value, BaggageEntryMetadata.create(PROPAGATION_UNLIMITED)));
+        Baggage.fromContext(context)
+                .forEach((s, baggageEntry) -> builder.put(s, baggageEntry.getValue(), baggageEntry.getMetadata()));
         Baggage baggage = builder.build();
         Context withBaggage = context.with(baggage);
         if (log.isDebugEnabled()) {

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/propagation/BaggageTextMapPropagatorTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/propagation/BaggageTextMapPropagatorTests.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.otel.propagation;
+
+import io.micrometer.tracing.otel.bridge.OtelBaggageManager;
+import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntry;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import org.assertj.core.api.BDDAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+class BaggageTextMapPropagatorTests {
+
+    @Test
+    void should_append_baggage_to_existing_one() {
+        Baggage baggage = Baggage.current().toBuilder().put("foo", "bar").put("baz", "baz2").build();
+        Context parent = Context.current().with(baggage);
+        List<String> remoteFields = Arrays.asList("foo", "foo2");
+        BaggageTextMapPropagator baggageTextMapPropagator = new BaggageTextMapPropagator(remoteFields,
+                new OtelBaggageManager(new OtelCurrentTraceContext(), remoteFields, Collections.emptyList()));
+        Map<String, String> carrier = new HashMap<>();
+        carrier.put("foo", "bar");
+        carrier.put("foo2", "bar2");
+
+        Context extracted = baggageTextMapPropagator.extract(parent, carrier, new TextMapGetter<Map<String, String>>() {
+            @Override
+            public Iterable<String> keys(Map<String, String> carrier) {
+                return remoteFields;
+            }
+
+            @Override
+            public String get(Map<String, String> carrier, String key) {
+                return carrier.get(key);
+            }
+        });
+
+        Map<String, BaggageEntry> newBaggage = Baggage.fromContext(extracted).asMap();
+        BDDAssertions.then(newBaggage).containsOnlyKeys("foo", "foo2", "baz");
+    }
+
+}


### PR DESCRIPTION
without this change BaggageTextMapPropagator does not take into account the parent Context and its baggage. This could lead to overriding of eixsting baggage entries.

with this change we're appending to existing baggage entries.