### PR TITLE
Fix NPE from SimpleTracer#createBaggage

### DIFF
--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java
@@ -15,14 +15,12 @@
  */
 package io.micrometer.tracing.test.simple;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.Baggage;
 import io.micrometer.tracing.BaggageManager;
 import io.micrometer.tracing.TraceContext;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -63,9 +61,10 @@ public class SimpleBaggageManager implements BaggageManager {
         return baggageForName(traceContext, name);
     }
 
+    @Nullable
     private SimpleBaggageInScope baggageForName(TraceContext traceContext, String name) {
-        return this.baggagesByContext.get(traceContext).stream().filter(bag -> name.equalsIgnoreCase(bag.name()))
-                .findFirst().orElse(null);
+        return this.baggagesByContext.getOrDefault(traceContext, Collections.emptySet()).stream()
+                .filter(bag -> name.equalsIgnoreCase(bag.name())).findFirst().orElse(null);
     }
 
     @Override


### PR DESCRIPTION
I was writing a unittest with `SimpleTracer`.

Following this [baggage API documentation](https://micrometer.io/docs/tracing#_micrometer_tracing_baggage_api): 

```java
@Test
void foo() {
  Tracer tracer = new SimpleTracer();
  Span span = tracer.nextSpan().name("parent").start();

// Assuming that there's a span in scope...
  try (Tracer.SpanInScope ws = tracer.withSpan(span)) {

    // Not passing a TraceContext explicitly will bind the baggage to the
    // current TraceContext
    Baggage baggageForSpanInScopeOne = tracer.createBaggage("from_span_in_scope 1", "value 1");
    ...
  }
}
```

This gets NPE while creating a baggage.

It is because in `SimpleBaggageManager`

https://github.com/micrometer-metrics/tracing/blob/c93a098e5c81e001afeabaaf22b8d7afc4cb5503/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java#L66-L69

The `this.baggagesByContext.get(traceContext)` returns `null`. Then trying to `stream()` causes NPE.

This PR changes to handle the case when `baggagesByContext` map does not have a corresponding `traceContext`.
The callers of this method already handle `null` return value.
