### PR TITLE
Adds support for ObservationAwareSpanThreadLocalAccessor

### DIFF
--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleTraceContext.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleTraceContext.java
@@ -16,6 +16,9 @@
 package io.micrometer.tracing.test.simple;
 
 import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.internal.EncodingUtils;
+
+import java.util.Random;
 
 /**
  * A test implementation of a trace context.
@@ -24,6 +27,8 @@ import io.micrometer.tracing.TraceContext;
  * @since 1.0.0
  */
 public class SimpleTraceContext implements TraceContext {
+
+    private static final Random random = new Random();
 
     private volatile String traceId = "";
 
@@ -83,6 +88,16 @@ public class SimpleTraceContext implements TraceContext {
      */
     public void setSampled(Boolean sampled) {
         this.sampled = sampled;
+    }
+
+    String generateId() {
+        return EncodingUtils.fromLong(random.nextLong());
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleTraceContext{" + "traceId='" + traceId + '\'' + ", parentId='" + parentId + '\'' + ", spanId='"
+                + spanId + '\'' + ", sampled=" + sampled + '}';
     }
 
 }

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleTracer.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleTracer.java
@@ -46,7 +46,21 @@ public class SimpleTracer implements Tracer {
 
     @Override
     public SimpleSpan nextSpan(Span parent) {
-        return new SimpleSpan();
+        SimpleSpan span = simpleSpan(parent);
+        this.spans.add(span);
+        return span;
+    }
+
+    private SimpleSpan simpleSpan(Span parent) {
+        SimpleSpan span = new SimpleSpan();
+        boolean hasParent = parent != null;
+        if (hasParent) {
+            span.context().setParentId(parent.context().spanId());
+        }
+        String traceId = hasParent ? parent.context().traceId() : span.context().generateId();
+        span.context().setTraceId(traceId);
+        span.context().setSpanId(hasParent ? span.context().generateId() : traceId);
+        return span;
     }
 
     /**
@@ -100,7 +114,7 @@ public class SimpleTracer implements Tracer {
 
     @Override
     public SimpleSpan nextSpan() {
-        SimpleSpan span = new SimpleSpan();
+        SimpleSpan span = simpleSpan(currentSpan());
         this.spans.add(span);
         return span;
     }

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SpanAssert.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SpanAssert.java
@@ -717,6 +717,94 @@ public class SpanAssert<SELF extends SpanAssert<SELF>> extends AbstractAssert<SE
     }
 
     /**
+     * Verifies that this span has span id equal to the given value.
+     * <p>
+     * Examples: <pre><code class='java'> // assertions succeed
+     * assertThat(spanWithId123).hasSpanIdEqualTo("123");
+     *
+     * // assertions fail
+     * assertThat(spanWithId123).hasSpanIdEqualTo("234");</code></pre>
+     * @param spanId span id
+     * @return {@code this} assertion object.
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if span has a span id not equal to the given one
+     * @since 1.0.4
+     */
+    public SELF hasSpanIdEqualTo(String spanId) {
+        isNotNull();
+        if (!this.actual.getSpanId().equals(spanId)) {
+            failWithMessage("Span should have span id equal to <%s> but has <%s>", spanId, this.actual.getSpanId());
+        }
+        return (SELF) this;
+    }
+
+    /**
+     * Verifies that this span doesn't have span id equal to the given value.
+     * <p>
+     * Examples: <pre><code class='java'> // assertions succeed
+     * assertThat(spanWithId123).hasSpanIdEqualTo("234");
+     *
+     * // assertions fail
+     * assertThat(spanWithId123).hasSpanIdEqualTo("123");</code></pre>
+     * @param spanId span id
+     * @return {@code this} assertion object.
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if span has a span id equal to the given one
+     * @since 1.0.4
+     */
+    public SELF doesNotHaveSpanIdEqualTo(String spanId) {
+        isNotNull();
+        if (this.actual.getSpanId().equals(spanId)) {
+            failWithMessage("Span should not have span id equal to <%s>", spanId);
+        }
+        return (SELF) this;
+    }
+
+    /**
+     * Verifies that this span has trace id equal to the given value.
+     * <p>
+     * Examples: <pre><code class='java'> // assertions succeed
+     * assertThat(spanWithTraceId123).hasTraceIdEqualTo("123");
+     *
+     * // assertions fail
+     * assertThat(spanWithTraceId123).hasTraceIdEqualTo("234");</code></pre>
+     * @param spanId span id
+     * @return {@code this} assertion object.
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if span has a trace id not equal to the given one
+     * @since 1.0.4
+     */
+    public SELF hasTraceIdEqualTo(String spanId) {
+        isNotNull();
+        if (!this.actual.getTraceId().equals(spanId)) {
+            failWithMessage("Span should have trace id equal to <%s> but has <%s>", spanId, this.actual.getSpanId());
+        }
+        return (SELF) this;
+    }
+
+    /**
+     * Verifies that this span doesn't have trace id equal to the given value.
+     * <p>
+     * Examples: <pre><code class='java'> // assertions succeed
+     * assertThat(spanWithTraceId123).hasTraceIdEqualTo("234");
+     *
+     * // assertions fail
+     * assertThat(spanWithTraceId123).hasTraceIdEqualTo("123");</code></pre>
+     * @param spanId span id
+     * @return {@code this} assertion object.
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if span has a span id equal to the given one
+     * @since 1.0.4
+     */
+    public SELF doesNotHaveTraceIdEqualTo(String spanId) {
+        isNotNull();
+        if (this.actual.getTraceId().equals(spanId)) {
+            failWithMessage("Span should not have trace id equal to <%s>", spanId);
+        }
+        return (SELF) this;
+    }
+
+    /**
      * Syntactic sugar that extends {@link AbstractThrowableAssert} methods with an option
      * to go back to {@link SpanAssert}.
      *

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/contextpropagation/ObservationAwareSpanThreadLocalAccessorTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/contextpropagation/ObservationAwareSpanThreadLocalAccessorTests.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.test.contextpropagation;
+
+import io.micrometer.context.ContextExecutorService;
+import io.micrometer.context.ContextRegistry;
+import io.micrometer.context.ContextSnapshot;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.contextpropagation.ObservationAwareSpanThreadLocalAccessor;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
+import io.micrometer.tracing.test.simple.SimpleSpan;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class ObservationAwareSpanThreadLocalAccessorTests {
+
+    static final Logger log = LoggerFactory.getLogger(ObservationAwareSpanThreadLocalAccessorTests.class);
+
+    SimpleTracer tracer = new SimpleTracer();
+
+    ObservationRegistry observationRegistry = ObservationRegistry.create();
+
+    ContextRegistry contextRegistry = new ContextRegistry();
+
+    ExecutorService executorService = ContextExecutorService.wrap(Executors.newSingleThreadExecutor(),
+            () -> ContextSnapshot.captureAll(contextRegistry));
+
+    @BeforeEach
+    void setup() {
+        observationRegistry.observationConfig().observationHandler(new DefaultTracingObservationHandler(tracer));
+        contextRegistry.loadThreadLocalAccessors()
+            .registerThreadLocalAccessor(new ObservationAwareSpanThreadLocalAccessor(tracer));
+    }
+
+    @AfterEach
+    void close() {
+        executorService.shutdown();
+        then(tracer.currentSpan()).isNull();
+        then(observationRegistry.getCurrentObservationScope()).isNull();
+    }
+
+    @Test
+    void asyncTracingTestWithObservationAndManualSpans()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        Observation firstSpan = Observation.createNotStarted("First span", observationRegistry)
+            .highCardinalityKeyValue("test", "test");
+        try (Observation.Scope scope = firstSpan.start().openScope()) {
+            logWithSpan("Async in test with observation - before call");
+
+            SimpleSpan secondSpan = tracer.nextSpan().name("Second span").tag("test", "test");
+            try (Tracer.SpanInScope scope2 = this.tracer.withSpan(secondSpan.start())) {
+                logWithSpan("Async in test with span - before call");
+                Future<String> future = executorService.submit(this::asyncCall);
+                String spanIdFromFuture = future.get(1, TimeUnit.SECONDS);
+                logWithSpan("Async in test with span - after call");
+                then(spanIdFromFuture).isEqualTo(secondSpan.context().spanId());
+            }
+            finally {
+                secondSpan.end();
+            }
+
+            logWithSpan("Async in test with observation - after call");
+        }
+        finally {
+            firstSpan.stop();
+        }
+
+        Future<Boolean> submit = executorService.submit(() -> {
+            logWithSpan("There should be no span here");
+            return tracer.currentSpan() == null;
+        });
+        boolean noCurrentSpan = submit.get(1, TimeUnit.SECONDS);
+
+        Assertions.assertThat(noCurrentSpan).isTrue();
+
+    }
+
+    @Test
+    void asyncTracingTestWithManualSpansAndObservation()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        SimpleSpan firstSpan = tracer.nextSpan().name("First span").tag("test", "test");
+        try (Tracer.SpanInScope scope2 = this.tracer.withSpan(firstSpan.start())) {
+            logWithSpan("Async in test with span - before call");
+            Observation observation = Observation.createNotStarted("Second span", observationRegistry)
+                .highCardinalityKeyValue("test", "test");
+            try (Observation.Scope scope = observation.start().openScope()) {
+                SimpleSpan secondSpan = tracer.currentSpan();
+                logWithSpan("Async in test with observation - before call");
+                Future<String> future = executorService.submit(this::asyncCall);
+                String spanIdFromFuture = future.get(1, TimeUnit.SECONDS);
+                then(spanIdFromFuture).isEqualTo(secondSpan.context().spanId());
+                logWithSpan("Async in test with observation - after call");
+            }
+            logWithSpan("Async in test with span - after call");
+        }
+        finally {
+            firstSpan.end();
+        }
+
+        Future<Boolean> submit = executorService.submit(() -> {
+            logWithSpan("There should be no span here");
+            return tracer.currentSpan() == null;
+        });
+        boolean noCurrentSpan = submit.get(1, TimeUnit.SECONDS);
+
+        Assertions.assertThat(noCurrentSpan).isTrue();
+
+    }
+
+    @Test
+    void asyncTracingTestWithJustObservation() throws ExecutionException, InterruptedException, TimeoutException {
+        Observation firstObservation = Observation.createNotStarted("First span", observationRegistry)
+            .highCardinalityKeyValue("test", "test");
+        try (Observation.Scope scope = firstObservation.start().openScope()) {
+            logWithSpan("Async in test with span - before call");
+            String currentSpanId = tracer.currentSpan().context().spanId();
+            Future<String> future = executorService.submit(this::asyncCall);
+            String spanIdFromFuture = future.get(1, TimeUnit.SECONDS);
+            logWithSpan("Async in test with span - after call");
+            then(spanIdFromFuture).isEqualTo(currentSpanId);
+        }
+        finally {
+            firstObservation.stop();
+        }
+
+        Future<Boolean> submit = executorService.submit(() -> {
+            logWithSpan("There should be no span here");
+            return tracer.currentSpan() == null;
+        });
+        boolean noCurrentSpan = submit.get(1, TimeUnit.SECONDS);
+
+        Assertions.assertThat(noCurrentSpan).isTrue();
+
+    }
+
+    @Test
+    void asyncTracingTestWithJustSpans() throws ExecutionException, InterruptedException, TimeoutException {
+        Span secondSpan = tracer.nextSpan().name("Second span").tag("test", "test");
+        try (Tracer.SpanInScope scope2 = this.tracer.withSpan(secondSpan.start())) {
+            logWithSpan("Async in test with span - before call");
+            Future<String> future = executorService.submit(this::asyncCall);
+            String spanIdFromFuture = future.get(1, TimeUnit.SECONDS);
+            logWithSpan("Async in test with span - after call");
+            then(spanIdFromFuture).isEqualTo(secondSpan.context().spanId());
+        }
+        finally {
+            secondSpan.end();
+        }
+
+        Future<Boolean> submit = executorService.submit(() -> {
+            logWithSpan("There should be no span here");
+            return tracer.currentSpan() == null;
+        });
+        boolean noCurrentSpan = submit.get(1, TimeUnit.SECONDS);
+
+        Assertions.assertThat(noCurrentSpan).isTrue();
+
+    }
+
+    private String asyncCall() {
+        logWithSpan("TASK EXECUTOR");
+        if (tracer.currentSpan() == null) {
+            throw new AssertionError("Current span must not be null. Context propagation failed");
+        }
+        return tracer.currentSpan().context().spanId();
+    }
+
+    private void logWithSpan(String text) {
+        log.info(text + ". Current span ["
+                + (tracer.currentSpan() != null ? tracer.currentSpan().context().toString() : null) + "]");
+    }
+
+}

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SpanAssertTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SpanAssertTests.java
@@ -401,4 +401,66 @@ class SpanAssertTests {
         thenThrownBy(() -> assertThat(span).hasPortThatIsSet()).isInstanceOf(AssertionError.class);
     }
 
+    @Test
+    void should_not_fail_when_spanId_is_equal() {
+        SimpleSpan span = new SimpleSpan();
+
+        thenNoException().isThrownBy(() -> assertThat(span).hasSpanIdEqualTo(span.getSpanId()));
+    }
+
+    @Test
+    void should_fail_when_spanId_is_not_equal() {
+        SimpleSpan span = new SimpleSpan();
+        span.context().setSpanId("1");
+
+        thenThrownBy(() -> assertThat(span).hasSpanIdEqualTo("2")).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void should_not_fail_when_spanId_is_not_equal() {
+        SimpleSpan span = new SimpleSpan();
+        span.context().setSpanId("1");
+
+        thenNoException().isThrownBy(() -> assertThat(span).doesNotHaveSpanIdEqualTo("2"));
+    }
+
+    @Test
+    void should_fail_when_spanId_is_equal() {
+        SimpleSpan span = new SimpleSpan();
+
+        thenThrownBy(() -> assertThat(span).doesNotHaveSpanIdEqualTo(span.getSpanId()))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void should_not_fail_when_traceId_is_equal() {
+        SimpleSpan span = new SimpleSpan();
+
+        thenNoException().isThrownBy(() -> assertThat(span).hasTraceIdEqualTo(span.getSpanId()));
+    }
+
+    @Test
+    void should_fail_when_traceId_is_not_equal() {
+        SimpleSpan span = new SimpleSpan();
+        span.context().setTraceId("1");
+
+        thenThrownBy(() -> assertThat(span).hasTraceIdEqualTo("2")).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void should_not_fail_when_traceId_is_not_equal() {
+        SimpleSpan span = new SimpleSpan();
+        span.context().setTraceId("1");
+
+        thenNoException().isThrownBy(() -> assertThat(span).doesNotHaveTraceIdEqualTo("2"));
+    }
+
+    @Test
+    void should_fail_when_traceId_is_equal() {
+        SimpleSpan span = new SimpleSpan();
+
+        thenThrownBy(() -> assertThat(span).doesNotHaveTraceIdEqualTo(span.getSpanId()))
+            .isInstanceOf(AssertionError.class);
+    }
+
 }


### PR DESCRIPTION
without this change you can't propagate just micrometer tracing spans with context propagation

with this change we're introducing an ObservationAwareSpanThreadLocalAccessor that is a ThreadLocalAccessor that knows about the existence of the ObservationThreadLocalAccessor. If OTLA started a span, the OASTLA will back off. If there was no observation and no span there, OASTLA will return an instance of a span. Since ordering matters, OAWSTLA will not be registered in the SPI mechanism, the user will need to set the ContextPropagation registry manually to ensure that OASTLA is registered AFTER OTLA.

additionally I've enhanced the `SimpleTracer` span and trace id generation so that the tests for OASTLA could have been easily written.

fixes gh-206