### PR TITLE
Not creating scopes when resetting scope on trace handler

### DIFF
--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleSpan.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleSpan.java
@@ -65,7 +65,7 @@ public class SimpleSpan implements Span, FinishedSpan {
      * Creates a new instance of {@link SimpleSpan}.
      */
     public SimpleSpan() {
-        SimpleSpanAndScope.bindSpanToTraceContext(context(), this);
+        SimpleTracer.bindSpanToTraceContext(context(), this);
     }
 
     @Override

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleSpanAndScope.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleSpanAndScope.java
@@ -15,15 +15,13 @@
  */
 package io.micrometer.tracing.test.simple;
 
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.SpanAndScope;
 import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.Tracer;
+
+import java.util.Objects;
 
 /**
  * Container object for {@link Span} and its corresponding {@link Tracer.SpanInScope}.
@@ -33,8 +31,6 @@ import io.micrometer.tracing.Tracer;
  * @since 1.0.0
  */
 public class SimpleSpanAndScope extends SpanAndScope {
-
-    private static final Map<TraceContext, Span> traceContextToSpans = new ConcurrentHashMap<>();
 
     private final TraceContext traceContext;
 
@@ -54,7 +50,7 @@ public class SimpleSpanAndScope extends SpanAndScope {
      * @param scope scope
      */
     public SimpleSpanAndScope(TraceContext traceContext, @Nullable Tracer.SpanInScope scope) {
-        super(Objects.requireNonNull(traceContextToSpans.get(traceContext),
+        super(Objects.requireNonNull(SimpleTracer.getSpanForTraceContext(traceContext),
                 "You must create a span with this context before"), scope);
         this.traceContext = traceContext;
     }
@@ -65,24 +61,6 @@ public class SimpleSpanAndScope extends SpanAndScope {
      */
     public TraceContext getTraceContext() {
         return traceContext;
-    }
-
-    /**
-     * Binds the given {@link Span} to the given {@link TraceContext}.
-     * @param traceContext the traceContext to use to bind this span to
-     * @param span the span that needs to be bounded to the traceContext
-     */
-    static void bindSpanToTraceContext(TraceContext traceContext, Span span) {
-        traceContextToSpans.put(traceContext, span);
-    }
-
-    /**
-     * Returns the {@link Span} that is bounded to the given {@link TraceContext}.
-     * @param traceContext the traceContext to use to fetch the span
-     * @return the span that is bounded to the given traceContext (null if none)
-     */
-    static Span getSpanForTraceContext(TraceContext traceContext) {
-        return traceContextToSpans.get(traceContext);
     }
 
 }

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/CurrentTraceContext.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/CurrentTraceContext.java
@@ -137,6 +137,13 @@ public interface CurrentTraceContext {
      */
     interface Scope extends Closeable {
 
+        /**
+         * A noop implementation.
+         */
+        Scope NOOP = () -> {
+
+        };
+
         @Override
         void close();
 

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.handler;
+
+import io.micrometer.tracing.CurrentTraceContext;
+import io.micrometer.tracing.Span;
+
+class RevertingScope implements CurrentTraceContext.Scope {
+
+    private final TracingObservationHandler.TracingContext tracingContext;
+
+    private final CurrentTraceContext.Scope currentScope;
+
+    private final CurrentTraceContext.Scope previousScope;
+
+    private final Span previousSpan;
+
+    RevertingScope(TracingObservationHandler.TracingContext tracingContext, CurrentTraceContext.Scope currentScope,
+            CurrentTraceContext.Scope previousScope, Span previousSpan) {
+        this.tracingContext = tracingContext;
+        this.currentScope = currentScope;
+        this.previousScope = previousScope;
+        this.previousSpan = previousSpan;
+    }
+
+    @Override
+    public void close() {
+        this.currentScope.close();
+        this.tracingContext.setSpanAndScope(this.previousSpan, this.previousScope);
+    }
+
+    @Override
+    public String toString() {
+        return "RevertingScope{" + "tracingContext=" + tracingContext + ", currentScope=" + currentScope
+                + ", previousScope=" + previousScope + ", previousSpan=" + previousSpan + '}';
+    }
+
+}

--- a/micrometer-tracing/src/test/java/io/micrometer/tracing/handler/TracingObservationHandlerTests.java
+++ b/micrometer-tracing/src/test/java/io/micrometer/tracing/handler/TracingObservationHandlerTests.java
@@ -16,12 +16,14 @@
 package io.micrometer.tracing.handler;
 
 import io.micrometer.observation.Observation;
+import io.micrometer.tracing.CurrentTraceContext;
 import io.micrometer.tracing.Tracer;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
@@ -39,11 +41,13 @@ class TracingObservationHandlerTests {
     @Test
     void spanShouldBeClearedOnScopeReset() {
         Tracer tracer = mock(Tracer.class);
+        CurrentTraceContext currentTraceContext = mock(CurrentTraceContext.class);
+        given(tracer.currentTraceContext()).willReturn(currentTraceContext);
         TracingObservationHandler<Observation.Context> handler = () -> tracer;
 
         handler.onScopeReset(new Observation.Context());
 
-        then(tracer).should().withSpan(isNull());
+        then(currentTraceContext).should().maybeScope(isNull());
     }
 
     @Test


### PR DESCRIPTION
without this change, we're using the `tracer.withSpan(null)` to reset the thread local, however the better alternative is to use the `CurrentTraceContext.maybeScope` mechanism.

with this change we're changing the way the `TracingObservationHandler` is clearing scopes. We also needed to improve the testing tracer to support these changes

fixes gh-213