### PR TITLE
Avoid calling exporter if no traces to send

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/CompositeSpanExporter.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/CompositeSpanExporter.java
@@ -70,6 +70,9 @@ public class CompositeSpanExporter implements io.opentelemetry.sdk.trace.export.
             }
             return OtelFinishedSpan.toOtel(finishedSpan);
         }).collect(Collectors.toList());
+        if (changedSpanData.isEmpty()) {
+            return CompletableResultCode.ofSuccess();
+        }
         List<CompletableResultCode> results = new ArrayList<>();
         changedSpanData.forEach(spanData -> {
             this.reporters.forEach(reporter -> {

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/CompositeSpanExporterTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/CompositeSpanExporterTests.java
@@ -91,6 +91,28 @@ class CompositeSpanExporterTests {
         BDDAssertions.then(resultCode.isSuccess()).isTrue();
     }
 
+    @Test
+    void should_not_call_exporter_if_no_spans() {
+        SpanExporter exporter = mock(SpanExporter.class);
+        given(exporter.export(BDDMockito.any())).willReturn(CompletableResultCode.ofSuccess());
+        SpanExportingPredicate predicate = span -> span.getName().equals("foo");
+        SpanFilter filter = span -> span.setName("baz");
+        SpanReporter reporter = mock(SpanReporter.class);
+
+        SpanData barSpan = new CustomSpanData("bar");
+
+        CompletableResultCode resultCode = new CompositeSpanExporter(Collections.singleton(exporter),
+            Collections.singletonList(predicate), Collections.singletonList(reporter),
+            Collections.singletonList(filter))
+            .export(Collections.singletonList(barSpan));
+
+        then(reporter).shouldHaveNoInteractions();
+
+
+        then(exporter).shouldHaveNoInteractions();
+        BDDAssertions.then(resultCode.isSuccess()).isTrue();
+    }
+
     static class CustomSpanData implements SpanData {
 
         private String name;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/CompositeSpanExporterTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/CompositeSpanExporterTests.java
@@ -102,12 +102,11 @@ class CompositeSpanExporterTests {
         SpanData barSpan = new CustomSpanData("bar");
 
         CompletableResultCode resultCode = new CompositeSpanExporter(Collections.singleton(exporter),
-            Collections.singletonList(predicate), Collections.singletonList(reporter),
-            Collections.singletonList(filter))
+                Collections.singletonList(predicate), Collections.singletonList(reporter),
+                Collections.singletonList(filter))
             .export(Collections.singletonList(barSpan));
 
         then(reporter).shouldHaveNoInteractions();
-
 
         then(exporter).shouldHaveNoInteractions();
         BDDAssertions.then(resultCode.isSuccess()).isTrue();


### PR DESCRIPTION
`CompositeSpanExporter` is calling the exporter even if there are no traces to send. Avoid calling the exporter when the traces list if empty.