### PR TITLE
wip: support long, double and boolean for tags #234

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BraveSpanBuilderTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BraveSpanBuilderTests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 
 class BraveSpanBuilderTests {
@@ -68,6 +69,21 @@ class BraveSpanBuilderTests {
             .containsEntry("links[0].tags[tag2]", "value2")
             .containsEntry("links[1].traceId", span1.context().traceId())
             .containsEntry("links[1].spanId", span1.context().spanId());
+    }
+
+    @Test
+    void should_set_non_string_tags() {
+        new BraveSpanBuilder(tracing.tracer()).tag("string", "string")
+            .tag("double", 2.5)
+            .tag("long", 2)
+            .tag("boolean", true)
+            .start()
+            .end();
+
+        assertThat(handler.get(0).tags()).containsEntry("string", "string")
+            .containsEntry("double", "2.5")
+            .containsEntry("long", "2")
+            .containsEntry("boolean", "true");
     }
 
     private Map<String, String> tags() {

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BraveSpanTest.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BraveSpanTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.brave.bridge;
+
+import brave.Tracing;
+import brave.test.TestSpanHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BraveSpanTest {
+
+    TestSpanHandler handler = new TestSpanHandler();
+
+    Tracing tracing = Tracing.newBuilder().addSpanHandler(handler).build();
+
+    @Test
+    void should_set_non_string_tags() {
+        new BraveSpan(tracing.tracer().nextSpan()).start()
+            .tag("string", "string")
+            .tag("double", 2.5)
+            .tag("long", 2)
+            .tag("boolean", true)
+            .end();
+
+        assertThat(handler.get(0).tags()).containsEntry("string", "string")
+            .containsEntry("double", "2.5")
+            .containsEntry("long", "2")
+            .containsEntry("boolean", "true");
+    }
+
+}

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
@@ -108,6 +108,24 @@ class OtelSpan implements Span {
     }
 
     @Override
+    public Span tag(String key, long value) {
+        this.delegate.setAttribute(key, value);
+        return new OtelSpan(this.delegate);
+    }
+
+    @Override
+    public Span tag(String key, double value) {
+        this.delegate.setAttribute(key, value);
+        return new OtelSpan(this.delegate);
+    }
+
+    @Override
+    public Span tag(String key, boolean value) {
+        this.delegate.setAttribute(key, value);
+        return new OtelSpan(this.delegate);
+    }
+
+    @Override
     public void end(long time, TimeUnit timeUnit) {
         this.delegate.end(time, timeUnit);
     }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilder.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilder.java
@@ -90,6 +90,24 @@ class OtelSpanBuilder implements Span.Builder {
     }
 
     @Override
+    public Span.Builder tag(String key, long value) {
+        this.delegate.setAttribute(key, value);
+        return this;
+    }
+
+    @Override
+    public Span.Builder tag(String key, double value) {
+        this.delegate.setAttribute(key, value);
+        return this;
+    }
+
+    @Override
+    public Span.Builder tag(String key, boolean value) {
+        this.delegate.setAttribute(key, value);
+        return this;
+    }
+
+    @Override
     public Span.Builder error(Throwable throwable) {
         this.error = throwable;
         return this;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanCustomizer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanCustomizer.java
@@ -43,6 +43,24 @@ public class OtelSpanCustomizer implements SpanCustomizer {
     }
 
     @Override
+    public SpanCustomizer tag(String key, long value) {
+        currentSpan().setAttribute(key, value);
+        return this;
+    }
+
+    @Override
+    public SpanCustomizer tag(String key, double value) {
+        currentSpan().setAttribute(key, value);
+        return this;
+    }
+
+    @Override
+    public SpanCustomizer tag(String key, boolean value) {
+        currentSpan().setAttribute(key, value);
+        return this;
+    }
+
+    @Override
     public SpanCustomizer event(String value) {
         currentSpan().addEvent(value);
         return this;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelSpanTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelSpanTests.java
@@ -28,23 +28,27 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 class OtelSpanTests {
 
+    ArrayListSpanProcessor processor = new ArrayListSpanProcessor();
+
+    SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+        .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())
+        .addSpanProcessor(processor)
+        .build();
+
+    OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder()
+        .setTracerProvider(sdkTracerProvider)
+        .setPropagators(ContextPropagators.create(B3Propagator.injectingSingleHeader()))
+        .build();
+
+    io.opentelemetry.api.trace.Tracer otelTracer = openTelemetrySdk.getTracer("io.micrometer.micrometer-tracing");
+
     @Test
     void should_set_status_to_error_when_recording_exception() {
-        ArrayListSpanProcessor arrayListSpanProcessor = new ArrayListSpanProcessor();
-        SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
-            .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())
-            .addSpanProcessor(arrayListSpanProcessor)
-            .build();
-        OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder()
-            .setTracerProvider(sdkTracerProvider)
-            .setPropagators(ContextPropagators.create(B3Propagator.injectingSingleHeader()))
-            .build();
-        io.opentelemetry.api.trace.Tracer otelTracer = openTelemetrySdk.getTracer("io.micrometer.micrometer-tracing");
         OtelSpan otelSpan = new OtelSpan(otelTracer.spanBuilder("foo").startSpan());
 
         otelSpan.error(new RuntimeException("boom!")).end();
 
-        SpanData poll = arrayListSpanProcessor.spans().poll();
+        SpanData poll = processor.spans().poll();
         then(poll.getStatus()).isEqualTo(StatusData.create(StatusCode.ERROR, "boom!"));
         then(poll.getEvents()).hasSize(1);
         then(poll.getEvents().get(0).getAttributes().asMap().values()).containsAnyOf("boom!");

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/Span.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/Span.java
@@ -152,6 +152,36 @@ public interface Span extends io.micrometer.tracing.SpanCustomizer {
     Span tag(String key, String value);
 
     /**
+     * Sets a tag on this span.
+     * @param key tag key
+     * @param value tag value
+     * @return this span
+     */
+    default Span tag(String key, long value) {
+        return tag(key, String.valueOf(value));
+    }
+
+    /**
+     * Sets a tag on this span.
+     * @param key tag key
+     * @param value tag value
+     * @return this span
+     */
+    default Span tag(String key, double value) {
+        return tag(key, String.valueOf(value));
+    }
+
+    /**
+     * Sets a tag on this span.
+     * @param key tag key
+     * @param value tag value
+     * @return this span
+     */
+    default Span tag(String key, boolean value) {
+        return tag(key, String.valueOf(value));
+    }
+
+    /**
      * Records an exception for this span.
      * @param throwable to record
      * @return this span
@@ -332,6 +362,36 @@ public interface Span extends io.micrometer.tracing.SpanCustomizer {
          * @return this
          */
         Builder tag(String key, String value);
+
+        /**
+         * Sets a tag on the span.
+         * @param key tag key
+         * @param value tag value
+         * @return this
+         */
+        default Builder tag(String key, long value) {
+            return tag(key, String.valueOf(value));
+        }
+
+        /**
+         * Sets a tag on the span.
+         * @param key tag key
+         * @param value tag value
+         * @return this
+         */
+        default Builder tag(String key, double value) {
+            return tag(key, String.valueOf(value));
+        }
+
+        /**
+         * Sets a tag on the span.
+         * @param key tag key
+         * @param value tag value
+         * @return this
+         */
+        default Builder tag(String key, boolean value) {
+            return tag(key, String.valueOf(value));
+        }
 
         /**
          * Sets an error on the span.

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/SpanCustomizer.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/SpanCustomizer.java
@@ -60,6 +60,36 @@ public interface SpanCustomizer {
     SpanCustomizer tag(String key, String value);
 
     /**
+     * Sets a tag on a span.
+     * @param key tag key
+     * @param value tag value
+     * @return this, for chaining
+     */
+    default SpanCustomizer tag(String key, long value) {
+        return tag(key, String.valueOf(value));
+    }
+
+    /**
+     * Sets a tag on a span.
+     * @param key tag key
+     * @param value tag value
+     * @return this, for chaining
+     */
+    default SpanCustomizer tag(String key, double value) {
+        return tag(key, String.valueOf(value));
+    }
+
+    /**
+     * Sets a tag on a span.
+     * @param key tag key
+     * @param value tag value
+     * @return this, for chaining
+     */
+    default SpanCustomizer tag(String key, boolean value) {
+        return tag(key, String.valueOf(value));
+    }
+
+    /**
      * Sets an event on a span.
      * @param value event name
      * @return this, for chaining


### PR DESCRIPTION
This is only draft.

Brave doesn't support other types to be set as tags, so primitives will be converted into string (this is safe).

Will make it fancy, after some preliminary idea approval