### PR TITLE
Propagator JavaDoc references Open Telemetry

### DIFF
--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/propagation/Propagator.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/propagation/Propagator.java
@@ -69,7 +69,7 @@ public interface Propagator {
     <C> Span.Builder extract(C carrier, Getter<C> getter);
 
     /**
-     * Class that allows a {@code TextMapPropagator} to set propagated fields into a
+     * Class that allows a {@code Propagator} to set propagated fields into a
      * carrier.
      *
      * <p>
@@ -99,7 +99,7 @@ public interface Propagator {
     }
 
     /**
-     * Interface that allows a {@code TextMapPropagator} to read propagated fields from a
+     * Interface that allows a {@code Propagator} to read propagated fields from a
      * carrier.
      *
      * <p>

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/propagation/Propagator.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/propagation/Propagator.java
@@ -69,8 +69,7 @@ public interface Propagator {
     <C> Span.Builder extract(C carrier, Getter<C> getter);
 
     /**
-     * Class that allows a {@code Propagator} to set propagated fields into a
-     * carrier.
+     * Class that allows a {@code Propagator} to set propagated fields into a carrier.
      *
      * <p>
      * {@code Setter} is stateless and allows to be saved as a constant to avoid runtime


### PR DESCRIPTION
Replace reference to Open telemetry classes by the Micrometer ones.

See [gh_230](https://github.com/micrometer-metrics/tracing/issues/230)