### PR TITLE
Fix lost baggage if more than one

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageInScope.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageInScope.java
@@ -136,7 +136,10 @@ class OtelBaggageInScope implements io.micrometer.tracing.Baggage, BaggageInScop
         if (context == null) {
             context = Context.current();
         }
-        Baggage baggage = Baggage.builder().put(entry.getKey(), entry.getValue(), entry.getMetadata()).build();
+        Baggage baggage = Baggage.fromContext(context)
+            .toBuilder()
+            .put(entry.getKey(), entry.getValue(), entry.getMetadata())
+            .build();
         Context updated = context.with(baggage);
         Scope scope = updated.makeCurrent();
         this.scope.set(scope);

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/BaggageTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/BaggageTests.java
@@ -40,6 +40,10 @@ class BaggageTests {
 
     public static final String VALUE_1 = "value1";
 
+    public static final String KEY_2 = "key2";
+
+    public static final String VALUE_2 = "value2";
+
     SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
         .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())
         .build();
@@ -71,9 +75,11 @@ class BaggageTests {
         Span span = tracer.nextSpan().start();
         try (Tracer.SpanInScope spanInScope = tracer.withSpan(span)) {
             // WHEN
-            try (BaggageInScope bs = this.tracer.createBaggageInScope(KEY_1, VALUE_1)) {
+            try (BaggageInScope bs1 = this.tracer.createBaggageInScope(KEY_1, VALUE_1);
+                    BaggageInScope bs2 = this.tracer.createBaggageInScope(KEY_2, VALUE_2)) {
                 // THEN
                 then(tracer.getBaggage(KEY_1).get()).isEqualTo(VALUE_1);
+                then(tracer.getBaggage(KEY_2).get()).isEqualTo(VALUE_2);
             }
         }
     }


### PR DESCRIPTION
When adding more than one baggage entry, only the last value is kept. 

See the modified test which adds KEY_2 and VALUE_2. Only KEY_2 is kept and KEY_1 entry disappears. The original implem always creates a new Baggage with every `createBaggageInScope`

This pull request fixes this problem by having the every baggage entry be added on top of the existing baggage map in `Context.current()`.