### PR TITLE
Deprecates everything related to HTTP

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpClientHandler.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpClientHandler.java
@@ -28,7 +28,9 @@ import io.micrometer.tracing.http.HttpClientHandler;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class BraveHttpClientHandler implements HttpClientHandler {
 
     private static final InternalLogger log = InternalLoggerFactory.getInstance(BraveHttpClientHandler.class);

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpClientRequest.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpClientRequest.java
@@ -15,17 +15,19 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
+import io.micrometer.tracing.http.HttpClientRequest;
+
 import java.util.Collection;
 import java.util.Collections;
-
-import io.micrometer.tracing.http.HttpClientRequest;
 
 /**
  * Brave implementation of a {@link HttpClientRequest}.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 class BraveHttpClientRequest implements HttpClientRequest {
 
     final brave.http.HttpClientRequest delegate;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpClientResponse.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpClientResponse.java
@@ -15,18 +15,20 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import io.micrometer.tracing.http.HttpClientRequest;
 import io.micrometer.tracing.http.HttpClientResponse;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Brave implementation of a {@link HttpClientResponse}.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 class BraveHttpClientResponse implements HttpClientResponse {
 
     final brave.http.HttpClientResponse delegate;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpRequest.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpRequest.java
@@ -15,18 +15,20 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import io.micrometer.observation.transport.Kind;
 import io.micrometer.tracing.http.HttpRequest;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Brave implementation of a {@link HttpRequest}.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 class BraveHttpRequest implements HttpRequest {
 
     final brave.http.HttpRequest delegate;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpRequestParser.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpRequestParser.java
@@ -25,7 +25,9 @@ import io.micrometer.tracing.http.HttpRequestParser;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class BraveHttpRequestParser implements HttpRequestParser {
 
     final brave.http.HttpRequestParser delegate;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpResponse.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpResponse.java
@@ -15,19 +15,21 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import io.micrometer.observation.transport.Kind;
 import io.micrometer.tracing.http.HttpRequest;
 import io.micrometer.tracing.http.HttpResponse;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Brave implementation of a {@link HttpResponse}.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 class BraveHttpResponse implements HttpResponse {
 
     final brave.http.HttpResponse delegate;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpResponseParser.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpResponseParser.java
@@ -25,7 +25,9 @@ import io.micrometer.tracing.http.HttpResponseParser;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class BraveHttpResponseParser implements HttpResponseParser {
 
     final brave.http.HttpResponseParser delegate;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpServerHandler.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpServerHandler.java
@@ -25,7 +25,9 @@ import io.micrometer.tracing.http.HttpServerHandler;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class BraveHttpServerHandler implements HttpServerHandler {
 
     final brave.http.HttpServerHandler<brave.http.HttpServerRequest, brave.http.HttpServerResponse> delegate;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpServerRequest.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpServerRequest.java
@@ -15,18 +15,20 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import io.micrometer.observation.transport.Kind;
 import io.micrometer.tracing.http.HttpServerRequest;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Brave implementation of a {@link HttpServerRequest}.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 class BraveHttpServerRequest implements HttpServerRequest {
 
     private static final boolean JAVAX_SERVLET_ON_THE_CLASSPATH = isClassPresent("javax.servlet.ServletRequest");

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpServerResponse.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveHttpServerResponse.java
@@ -15,19 +15,21 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import io.micrometer.observation.transport.Kind;
 import io.micrometer.tracing.http.HttpServerRequest;
 import io.micrometer.tracing.http.HttpServerResponse;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Brave implementation of a {@link HttpServerResponse}.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 class BraveHttpServerResponse implements HttpServerResponse {
 
     final brave.http.HttpServerResponse delegate;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveSamplerFunction.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveSamplerFunction.java
@@ -15,9 +15,8 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
-import brave.sampler.SamplerFunctions;
-import io.micrometer.tracing.http.HttpRequest;
 import io.micrometer.tracing.SamplerFunction;
+import io.micrometer.tracing.http.HttpRequest;
 
 /**
  * Brave implementation of a {@link SamplerFunction}.
@@ -39,19 +38,13 @@ public final class BraveSamplerFunction<T> implements SamplerFunction<T> {
         this.samplerFunction = samplerFunction;
     }
 
-    static <T, V> brave.sampler.SamplerFunction<V> toBrave(SamplerFunction<T> samplerFunction, Class<T> input,
-            Class<V> braveInput) {
-        if (input.equals(HttpRequest.class) && braveInput.equals(brave.http.HttpRequest.class)) {
-            return arg -> samplerFunction.trySample((T) BraveHttpRequest.fromBrave((brave.http.HttpRequest) arg));
-        }
-        return SamplerFunctions.deferDecision();
-    }
-
     /**
      * Converts from Tracing to Brave.
      * @param samplerFunction Tracing version
      * @return Brave version
+     * @deprecated scheduled for removal in 1.4.0
      */
+    @Deprecated
     public static brave.sampler.SamplerFunction<brave.http.HttpRequest> toHttpBrave(
             SamplerFunction<HttpRequest> samplerFunction) {
         return arg -> samplerFunction.trySample(BraveHttpRequest.fromBrave(arg));

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/DefaultHttpClientAttributesGetter.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/DefaultHttpClientAttributesGetter.java
@@ -29,7 +29,9 @@ import java.util.List;
  *
  * @author Nikita Salnikov-Tarnovski
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class DefaultHttpClientAttributesGetter
         implements HttpClientAttributesGetter<HttpClientRequest, HttpClientResponse> {
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/DefaultHttpServerAttributesExtractor.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/DefaultHttpServerAttributesExtractor.java
@@ -29,7 +29,9 @@ import java.util.List;
  *
  * @author Nikita Salnikov-Tarnovski
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class DefaultHttpServerAttributesExtractor
         implements HttpServerAttributesGetter<HttpServerRequest, HttpServerResponse> {
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/HttpRequestNetClientAttributesExtractor.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/HttpRequestNetClientAttributesExtractor.java
@@ -24,7 +24,9 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributes
  * Extracts OpenTelemetry network semantic attributes value for client http spans.
  *
  * @author Nikita Salnikov-Tarnovski
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 class HttpRequestNetClientAttributesExtractor
         implements NetClientAttributesGetter<HttpClientRequest, HttpClientResponse> {
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/HttpRequestNetServerAttributesExtractor.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/HttpRequestNetServerAttributesExtractor.java
@@ -26,7 +26,9 @@ import java.net.URI;
  * Extracts OpenTelemetry network semantic attributes value for server http spans.
  *
  * @author Nikita Salnikov-Tarnovski
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 class HttpRequestNetServerAttributesExtractor
         implements NetServerAttributesGetter<HttpServerRequest, HttpServerResponse> {
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelHttpClientHandler.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelHttpClientHandler.java
@@ -44,7 +44,9 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributes
  * @author Marcin Grzejszczak
  * @author Nikita Salnikov-Tarnovski
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class OtelHttpClientHandler implements HttpClientHandler {
 
     private static final InternalLogger log = InternalLoggerFactory.getInstance(OtelHttpClientHandler.class);

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelHttpServerHandler.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelHttpServerHandler.java
@@ -39,7 +39,9 @@ import java.util.regex.Pattern;
  * @author Marcin Grzejszczak
  * @author Nikita Salnikov-Tarnovski
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class OtelHttpServerHandler implements HttpServerHandler {
 
     private static final InternalLogger log = InternalLoggerFactory.getInstance(OtelHttpClientHandler.class);

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/PathAttributeExtractor.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/PathAttributeExtractor.java
@@ -24,6 +24,10 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.SemanticAttributes;
 
+/**
+ * @deprecated scheduled for removal in 1.4.0
+ */
+@Deprecated
 class PathAttributeExtractor implements AttributesExtractor<HttpRequest, HttpResponse> {
 
     private static final AttributeKey<String> HTTP_PATH = AttributeKey.stringKey("http.path");

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/SkipPatternSampler.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/SkipPatternSampler.java
@@ -15,17 +15,19 @@
  */
 package io.micrometer.tracing.otel.bridge;
 
-import java.util.regex.Pattern;
-
-import io.micrometer.tracing.http.HttpRequest;
 import io.micrometer.tracing.SamplerFunction;
+import io.micrometer.tracing.http.HttpRequest;
+
+import java.util.regex.Pattern;
 
 /**
  * Decides if sampling should take place for the given request.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class SkipPatternSampler implements SamplerFunction<HttpRequest> {
 
     private final Pattern pattern;

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/BuildingBlocks.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/BuildingBlocks.java
@@ -15,10 +15,6 @@
  */
 package io.micrometer.tracing.test.reporter;
 
-import java.util.Deque;
-import java.util.List;
-import java.util.function.BiConsumer;
-
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.tracing.Tracer;
@@ -26,6 +22,10 @@ import io.micrometer.tracing.exporter.FinishedSpan;
 import io.micrometer.tracing.http.HttpClientHandler;
 import io.micrometer.tracing.http.HttpServerHandler;
 import io.micrometer.tracing.propagation.Propagator;
+
+import java.util.Deque;
+import java.util.List;
+import java.util.function.BiConsumer;
 
 /**
  * Building blocks for reporters and tracers.
@@ -51,13 +51,17 @@ public interface BuildingBlocks {
     /**
      * Returns an {@link HttpServerHandler}.
      * @return http server handler
+     * @deprecated scheduled for removal in 1.4.0
      */
+    @Deprecated
     HttpServerHandler getHttpServerHandler();
 
     /**
      * Returns an {@link HttpClientHandler}.
      * @return http client handler
+     * @deprecated scheduled for removal in 1.4.0
      */
+    @Deprecated
     HttpClientHandler getHttpClientHandler();
 
     /**

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/inmemory/InMemoryBraveSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/inmemory/InMemoryBraveSetup.java
@@ -92,8 +92,10 @@ public final class InMemoryBraveSetup implements AutoCloseable {
 
         private Function<Tracing, HttpTracing> httpTracing;
 
+        @Deprecated
         private Function<HttpTracing, HttpServerHandler> httpServerHandler;
 
+        @Deprecated
         private Function<HttpTracing, HttpClientHandler> httpClientHandler;
 
         private Function<BraveBuildingBlocks, ObservationHandler<? extends Observation.Context>> handlers;
@@ -115,8 +117,10 @@ public final class InMemoryBraveSetup implements AutoCloseable {
 
             private final HttpTracing httpTracing;
 
+            @Deprecated
             private final HttpServerHandler httpServerHandler;
 
+            @Deprecated
             private final HttpClientHandler httpClientHandler;
 
             private final BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizers;
@@ -158,11 +162,21 @@ public final class InMemoryBraveSetup implements AutoCloseable {
                 return this.propagator;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http server handler
+             */
+            @Deprecated
             @Override
             public HttpServerHandler getHttpServerHandler() {
                 return this.httpServerHandler;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http client handler
+             */
+            @Deprecated
             @Override
             public HttpClientHandler getHttpClientHandler() {
                 return this.httpClientHandler;

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/inmemory/InMemoryOtelSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/inmemory/InMemoryOtelSetup.java
@@ -101,8 +101,10 @@ public final class InMemoryOtelSetup implements AutoCloseable {
 
         private BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizers;
 
+        @Deprecated
         private Function<OpenTelemetrySdk, HttpServerHandler> httpServerHandler;
 
+        @Deprecated
         private Function<OpenTelemetrySdk, HttpClientHandler> httpClientHandler;
 
         private Function<OtelBuildingBlocks, ObservationHandler<? extends Observation.Context>> handlers;
@@ -120,8 +122,10 @@ public final class InMemoryOtelSetup implements AutoCloseable {
 
             private final OtelPropagator propagator;
 
+            @Deprecated
             private final HttpServerHandler httpServerHandler;
 
+            @Deprecated
             private final HttpClientHandler httpClientHandler;
 
             private final BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizers;
@@ -156,11 +160,21 @@ public final class InMemoryOtelSetup implements AutoCloseable {
                 return this.otelTracer;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http server handler
+             */
+            @Deprecated
             @Override
             public HttpServerHandler getHttpServerHandler() {
                 return this.httpServerHandler;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http client handler
+             */
+            @Deprecated
             @Override
             public HttpClientHandler getHttpClientHandler() {
                 return this.httpClientHandler;

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/WavefrontBraveSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/WavefrontBraveSetup.java
@@ -15,15 +15,6 @@
  */
 package io.micrometer.tracing.test.reporter.wavefront;
 
-import java.util.Deque;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import brave.Tracing;
 import brave.handler.SpanHandler;
 import brave.http.HttpTracing;
@@ -37,13 +28,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
-import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
-import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
-import io.micrometer.tracing.brave.bridge.BraveFinishedSpan;
-import io.micrometer.tracing.brave.bridge.BraveHttpClientHandler;
-import io.micrometer.tracing.brave.bridge.BraveHttpServerHandler;
-import io.micrometer.tracing.brave.bridge.BravePropagator;
-import io.micrometer.tracing.brave.bridge.BraveTracer;
+import io.micrometer.tracing.brave.bridge.*;
 import io.micrometer.tracing.exporter.FinishedSpan;
 import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
 import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
@@ -53,6 +38,15 @@ import io.micrometer.tracing.http.HttpServerHandler;
 import io.micrometer.tracing.reporter.wavefront.WavefrontBraveSpanHandler;
 import io.micrometer.tracing.reporter.wavefront.WavefrontSpanHandler;
 import io.micrometer.tracing.test.reporter.BuildingBlocks;
+
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Provides Wavefront setup with Brave.
@@ -119,8 +113,10 @@ public final class WavefrontBraveSetup implements AutoCloseable {
 
         private Function<Tracing, HttpTracing> httpTracing;
 
+        @Deprecated
         private Function<HttpTracing, HttpServerHandler> httpServerHandler;
 
+        @Deprecated
         private Function<HttpTracing, HttpClientHandler> httpClientHandler;
 
         private Function<BraveBuildingBlocks, ObservationHandler<? extends Observation.Context>> handlers;
@@ -155,8 +151,10 @@ public final class WavefrontBraveSetup implements AutoCloseable {
 
             private final HttpTracing httpTracing;
 
+            @Deprecated
             private final HttpServerHandler httpServerHandler;
 
+            @Deprecated
             private final HttpClientHandler httpClientHandler;
 
             private final BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizers;
@@ -201,11 +199,21 @@ public final class WavefrontBraveSetup implements AutoCloseable {
                 return this.propagator;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http server handler
+             */
+            @Deprecated
             @Override
             public HttpServerHandler getHttpServerHandler() {
                 return this.httpServerHandler;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http client handler
+             */
+            @Deprecated
             @Override
             public HttpClientHandler getHttpClientHandler() {
                 return this.httpClientHandler;

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/WavefrontOtelSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/wavefront/WavefrontOtelSetup.java
@@ -15,17 +15,6 @@
  */
 package io.micrometer.tracing.test.reporter.wavefront;
 
-import java.util.Collections;
-import java.util.Deque;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import com.wavefront.sdk.common.application.ApplicationTags;
 import com.wavefront.sdk.common.clients.WavefrontClient;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -39,16 +28,7 @@ import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandle
 import io.micrometer.tracing.handler.PropagatingSenderTracingObservationHandler;
 import io.micrometer.tracing.http.HttpClientHandler;
 import io.micrometer.tracing.http.HttpServerHandler;
-import io.micrometer.tracing.otel.bridge.ArrayListSpanProcessor;
-import io.micrometer.tracing.otel.bridge.DefaultHttpClientAttributesGetter;
-import io.micrometer.tracing.otel.bridge.DefaultHttpServerAttributesExtractor;
-import io.micrometer.tracing.otel.bridge.OtelBaggageManager;
-import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext;
-import io.micrometer.tracing.otel.bridge.OtelFinishedSpan;
-import io.micrometer.tracing.otel.bridge.OtelHttpClientHandler;
-import io.micrometer.tracing.otel.bridge.OtelHttpServerHandler;
-import io.micrometer.tracing.otel.bridge.OtelPropagator;
-import io.micrometer.tracing.otel.bridge.OtelTracer;
+import io.micrometer.tracing.otel.bridge.*;
 import io.micrometer.tracing.propagation.Propagator;
 import io.micrometer.tracing.reporter.wavefront.WavefrontOtelSpanExporter;
 import io.micrometer.tracing.reporter.wavefront.WavefrontSpanHandler;
@@ -60,6 +40,13 @@ import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Provides Wavefront setup with OTel.
@@ -130,8 +117,10 @@ public final class WavefrontOtelSetup implements AutoCloseable {
 
         private BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizers;
 
+        @Deprecated
         private Function<OpenTelemetrySdk, HttpServerHandler> httpServerHandler;
 
+        @Deprecated
         private Function<OpenTelemetrySdk, HttpClientHandler> httpClientHandler;
 
         private Function<OtelBuildingBlocks, ObservationHandler<? extends Observation.Context>> handlers;
@@ -201,11 +190,21 @@ public final class WavefrontOtelSetup implements AutoCloseable {
                 return this.propagator;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http server handler
+             */
+            @Deprecated
             @Override
             public HttpServerHandler getHttpServerHandler() {
                 return this.httpServerHandler;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http client handler
+             */
+            @Deprecated
             @Override
             public HttpClientHandler getHttpClientHandler() {
                 return this.httpClientHandler;

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinBraveSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinBraveSetup.java
@@ -105,8 +105,10 @@ public final class ZipkinBraveSetup implements AutoCloseable {
 
         private Function<Tracing, HttpTracing> httpTracing;
 
+        @Deprecated
         private Function<HttpTracing, HttpServerHandler> httpServerHandler;
 
+        @Deprecated
         private Function<HttpTracing, HttpClientHandler> httpClientHandler;
 
         private Function<BraveBuildingBlocks, ObservationHandler<? extends Observation.Context>> handlers;
@@ -132,8 +134,10 @@ public final class ZipkinBraveSetup implements AutoCloseable {
 
             private final HttpTracing httpTracing;
 
+            @Deprecated
             private final HttpServerHandler httpServerHandler;
 
+            @Deprecated
             private final HttpClientHandler httpClientHandler;
 
             private final BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizers;
@@ -188,11 +192,21 @@ public final class ZipkinBraveSetup implements AutoCloseable {
                 return this.propagator;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http server handler
+             */
+            @Deprecated
             @Override
             public HttpServerHandler getHttpServerHandler() {
                 return this.httpServerHandler;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http client handler
+             */
+            @Deprecated
             @Override
             public HttpClientHandler getHttpClientHandler() {
                 return this.httpClientHandler;

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinOtelSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinOtelSetup.java
@@ -113,8 +113,10 @@ public final class ZipkinOtelSetup implements AutoCloseable {
 
         private BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizers;
 
+        @Deprecated
         private Function<OpenTelemetrySdk, HttpServerHandler> httpServerHandler;
 
+        @Deprecated
         private Function<OpenTelemetrySdk, HttpClientHandler> httpClientHandler;
 
         private Function<OtelBuildingBlocks, ObservationHandler<? extends Observation.Context>> handlers;
@@ -140,8 +142,10 @@ public final class ZipkinOtelSetup implements AutoCloseable {
 
             private final OtelPropagator propagator;
 
+            @Deprecated
             private final HttpServerHandler httpServerHandler;
 
+            @Deprecated
             private final HttpClientHandler httpClientHandler;
 
             private final BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizers;
@@ -194,11 +198,21 @@ public final class ZipkinOtelSetup implements AutoCloseable {
                 return this.otelTracer;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http server handler
+             */
+            @Deprecated
             @Override
             public HttpServerHandler getHttpServerHandler() {
                 return this.httpServerHandler;
             }
 
+            /**
+             * @deprecated scheduled for removal in 1.4.0
+             * @return http client handler
+             */
+            @Deprecated
             @Override
             public HttpClientHandler getHttpClientHandler() {
                 return this.httpClientHandler;

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleHttpClientHandler.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleHttpClientHandler.java
@@ -26,7 +26,9 @@ import io.micrometer.tracing.http.HttpClientHandler;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class SimpleHttpClientHandler implements HttpClientHandler {
 
     private final SimpleTracer simpleTracer;

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleHttpServerHandler.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleHttpServerHandler.java
@@ -25,7 +25,9 @@ import io.micrometer.tracing.http.HttpServerHandler;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public class SimpleHttpServerHandler implements HttpServerHandler {
 
     private final SimpleTracer simpleTracer;

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpClientHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpClientHandler.java
@@ -15,11 +15,9 @@
  */
 package io.micrometer.tracing.http;
 
-import io.micrometer.tracing.http.HttpClientRequest;
-import io.micrometer.tracing.http.HttpClientResponse;
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
-import io.micrometer.common.lang.Nullable;
 
 /**
  * This API is taken from OpenZipkin Brave.
@@ -31,7 +29,9 @@ import io.micrometer.common.lang.Nullable;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface HttpClientHandler {
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpClientRequest.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpClientRequest.java
@@ -25,7 +25,9 @@ import io.micrometer.observation.transport.Kind;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.10.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface HttpClientRequest extends HttpRequest {
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpClientResponse.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpClientResponse.java
@@ -27,7 +27,9 @@ import io.micrometer.observation.transport.Kind;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.10.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface HttpClientResponse extends HttpResponse {
 
     @Nullable

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpRequest.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpRequest.java
@@ -25,7 +25,9 @@ import io.micrometer.common.lang.Nullable;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.10.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface HttpRequest extends Request {
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpRequestParser.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpRequestParser.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.tracing.http;
 
-import io.micrometer.tracing.http.HttpRequest;
 import io.micrometer.tracing.SpanCustomizer;
 import io.micrometer.tracing.TraceContext;
 
@@ -27,7 +26,9 @@ import io.micrometer.tracing.TraceContext;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface HttpRequestParser {
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpResponse.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpResponse.java
@@ -25,7 +25,9 @@ import io.micrometer.common.lang.Nullable;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.10.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface HttpResponse extends Response {
 
     @Nullable

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpResponseParser.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpResponseParser.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.tracing.http;
 
-import io.micrometer.tracing.http.HttpResponse;
 import io.micrometer.tracing.SpanCustomizer;
 import io.micrometer.tracing.TraceContext;
 
@@ -27,7 +26,9 @@ import io.micrometer.tracing.TraceContext;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface HttpResponseParser {
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpServerHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpServerHandler.java
@@ -15,8 +15,6 @@
  */
 package io.micrometer.tracing.http;
 
-import io.micrometer.tracing.http.HttpServerRequest;
-import io.micrometer.tracing.http.HttpServerResponse;
 import io.micrometer.tracing.Span;
 
 /**
@@ -29,7 +27,9 @@ import io.micrometer.tracing.Span;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface HttpServerHandler {
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpServerRequest.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpServerRequest.java
@@ -25,7 +25,9 @@ import io.micrometer.observation.transport.Kind;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.10.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface HttpServerRequest extends HttpRequest {
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpServerResponse.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/HttpServerResponse.java
@@ -27,7 +27,9 @@ import io.micrometer.observation.transport.Kind;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.10.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface HttpServerResponse extends HttpResponse {
 
     @Nullable

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/Request.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/Request.java
@@ -15,9 +15,9 @@
  */
 package io.micrometer.tracing.http;
 
-import java.util.Collection;
-
 import io.micrometer.observation.transport.Kind;
+
+import java.util.Collection;
 
 /**
  * This API is taken from OpenZipkin Brave.
@@ -27,7 +27,9 @@ import io.micrometer.observation.transport.Kind;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.10.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface Request {
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/http/Response.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/http/Response.java
@@ -15,10 +15,10 @@
  */
 package io.micrometer.tracing.http;
 
-import java.util.Collection;
-
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.transport.Kind;
+
+import java.util.Collection;
 
 /**
  * This API is taken from OpenZipkin Brave.
@@ -28,7 +28,9 @@ import io.micrometer.observation.transport.Kind;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @since 1.10.0
+ * @deprecated scheduled for removal in 1.4.0
  */
+@Deprecated
 public interface Response {
 
     /**


### PR DESCRIPTION
we've decided in all instrumentation projects not to provide abstractions over transports (http, messaging etc.). That's why we should deprecate and eventually remove all HTTP related code from the tracing codebase.

fixes gh-350