### PR TITLE
Validating Observation termination doesn't invalidate scopes in other Threads

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/contextpropagation/ScopesTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/contextpropagation/ScopesTests.java
@@ -38,11 +38,19 @@ import io.micrometer.tracing.handler.TracingObservationHandler.TracingContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.util.context.Context;
 
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -145,6 +153,132 @@ class ScopesTests {
     }
 
     @Test
+    void should_open_and_close_scopes_with_reactor_multithreaded() {
+        ExecutorService executorService = Executors.newScheduledThreadPool(2);
+        Scheduler scheduler = Schedulers.fromExecutorService(executorService);
+
+        Observation obs1 = Observation.start("1", observationRegistry);
+
+        logger.info("SIZE BEFORE [" + CorrelationFlushScopeArrayReader.size() + "]");
+        Observation.Scope scope = obs1.openScope();
+        Span span1 = tracer.currentSpan();
+        logger.info("SPAN 1 [" + tracer.currentSpan() + "]");
+
+        Observation obs2 = Observation.start("2", observationRegistry);
+        Observation.Scope scope2 = obs2.openScope();
+        Span span2 = tracer.currentSpan();
+        logger.info("SPAN 2 [" + tracer.currentSpan() + "]");
+
+        logger.info("SIZE WITH 2 SCOPES [" + CorrelationFlushScopeArrayReader.size() + "]");
+
+        List<AssertionError> errorsInFlatMap = new CopyOnWriteArrayList<>();
+        List<AssertionError> errorsInInnerOnNext = new CopyOnWriteArrayList<>();
+        List<AssertionError> errorsInOuterOnNext = new CopyOnWriteArrayList<>();
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // First, let's open a couple scopes in multiple threads and terminate an
+        // Observation upon completion signal.
+
+        Flux.range(0, 2)
+            .flatMap(integer -> {
+                Observation obs3 = Observation.start("3", observationRegistry);
+                Span span3;
+                try (Observation.Scope scope3 = obs3.openScope()) {
+                    span3 = tracer.currentSpan();
+                    logger.info("SPAN 3 [" + tracer.currentSpan() + "]");
+                }
+
+                return Mono.just(integer)
+                           .subscribeOn(scheduler)
+                           .doOnNext(v -> {
+                               Span spanWEmpty = tracer.currentSpan();
+                               logger.info("[inner-flatMap] SPAN IN EMPTY [" + spanWEmpty + "]");
+                               assertInReactor(errorsInFlatMap, spanWEmpty, null);
+                               if (integer == 1) {
+                                   latch.countDown();
+                               } else {
+                                   try {
+                                       latch.await();
+                                   } catch (InterruptedException e) {
+                                       // ignore
+                                   }
+                               }
+                           })
+                           .contextWrite(context -> Context.empty())
+                           .doOnNext(v -> {
+                               Span spanWOnNext = tracer.currentSpan();
+                               logger.info("[inner-doOnNext] SPAN IN ON NEXT [" + spanWOnNext + "]");
+                               assertInReactor(errorsInInnerOnNext, spanWOnNext, span3);
+                           })
+                           .contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, obs3))
+                           // When stop is called in thread A, it mustn't close scopes
+                           // in thread B, which might still be open, as that would
+                           // cause errors and leaks.
+                           .doOnTerminate(obs3::stop);
+            }, 2, 1)
+            .doOnNext(integer -> {
+                Span spanWOnNext = tracer.currentSpan();
+                logger.info("[outer-doOnNext] SPAN IN ON NEXT [" + spanWOnNext + "]");
+                assertInReactor(errorsInOuterOnNext, spanWOnNext, span2);
+            })
+            .blockLast();
+
+        logger.info("Checking if there were no errors in reactor");
+        then(errorsInFlatMap).isEmpty();
+        then(errorsInOuterOnNext).isEmpty();
+        then(errorsInInnerOnNext).isEmpty();
+
+        logger.info("SPAN OUTSIDE REACTOR [" + tracer.currentSpan() + "]");
+        logger.info("SIZE AFTER [" + CorrelationFlushScopeArrayReader.size() + "]");
+        then(tracer.currentSpan()).isEqualTo(span2);
+
+        scope2.close();
+        obs2.stop();
+
+        logger.info("SIZE OUTSIDE CLOSE 2 [" + CorrelationFlushScopeArrayReader.size() + "]");
+        logger.info("SPAN AFTER CLOSE 2 [" + tracer.currentSpan() + "]");
+        then(tracer.currentSpan())
+            .as("Scopes should be restored to previous so current span should be Span 1 which is <%s>. Span 2 is <%s>",
+                span1, span2)
+            .isEqualTo(span1);
+
+        scope.close();
+        obs1.stop();
+
+        logger.info("SIZE AFTER CLOSE 1 [" + CorrelationFlushScopeArrayReader.size() + "]");
+        then(CorrelationFlushScopeArrayReader.size()).isZero();
+        then(tracer.currentSpan()).isNull();
+        logger.info("SPAN AFTER CLOSE 1 [" + tracer.currentSpan() + "]");
+
+        // Now let's validate if both threads have a clean state and have no leaks.
+
+        CountDownLatch cleanupLatch = new CountDownLatch(1);
+
+        executorService.submit(() -> {
+            Observation obs4 = Observation.start("4", observationRegistry);
+            try (Observation.Scope scope4 = obs4.openScope()) {
+                logger.info("FRESH SPAN AFTER [{}]", tracer.currentSpan());
+                cleanupLatch.await();
+            } catch (InterruptedException e) {
+                // ignore
+            }
+            obs4.stop();
+            logger.info("CLEAN SPAN AFTER [{}]", tracer.currentSpan());
+        });
+
+        executorService.submit(() -> {
+            Observation obs4 = Observation.start("4", observationRegistry);
+            try (Observation.Scope scope4 = obs4.openScope()) {
+                logger.info("FRESH SPAN AFTER [{}]", tracer.currentSpan());
+                cleanupLatch.countDown();
+            }
+            obs4.stop();
+            logger.info("CLEAN SPAN AFTER [{}]", tracer.currentSpan());
+        });
+    }
+
+    @Test
     void should_open_and_close_scopes_with_reactor_with_baggage() {
         Observation obs1 = Observation.start("1", observationRegistry);
 
@@ -202,6 +336,15 @@ class ScopesTests {
         then(tracingContext1.getBaggage()).isNullOrEmpty();
 
         then(tracer.getAllBaggage()).isEmpty();
+    }
+
+    private static void assertInReactor(List<AssertionError> errors, Span spanWOnNext, Span expectedSpan) {
+        try {
+            then(spanWOnNext).isEqualTo(expectedSpan);
+        }
+        catch (AssertionError er) {
+            errors.add(er);
+        }
     }
 
     private static void assertInReactor(AtomicReference<AssertionError> errors, Span spanWOnNext, Span expectedSpan) {


### PR DESCRIPTION
Introduced a test that validates Observation termination does not invalidate concurrently open scopes in other Threads when dealing with reactive code.

Resolves #397 
Follow-up to #363