### PR TITLE
Do not pass "walltime=0" to span event

### DIFF
--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/TracingObservationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/TracingObservationHandler.java
@@ -121,7 +121,12 @@ public interface TracingObservationHandler<T extends Observation.Context> extend
     @Override
     default void onEvent(Event event, T context) {
         long timestamp = event.getWallTime();
-        getRequiredSpan(context).event(event.getContextualName(), timestamp, TimeUnit.MILLISECONDS);
+        if (timestamp == 0) {
+            getRequiredSpan(context).event(event.getContextualName());
+        }
+        else {
+            getRequiredSpan(context).event(event.getContextualName(), timestamp, TimeUnit.MILLISECONDS);
+        }
     }
 
     @Override


### PR DESCRIPTION
For https://github.com/micrometer-metrics/tracing/issues/488

When `Event#getWallTime` returns `0`(default implementation), do not pass it to the underlying span event. Rather, let the span implementation determine the timestamp.

