### PR TITLE
Adds BaggageThreadLocalAccessor

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -17,4 +17,5 @@ asciidoc:
     chomp: 'all'
     include-java: 'example$docs-src/test/java/io/micrometer/docs'
     include-bridges-java: 'example$bridges-src'
+    include-integration-tests: 'example$/integration-src'
     include-resources: 'example$docs-src/test/resources'

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	testImplementation libs.mockitoCore
 	testImplementation libs.assertj
 	testImplementation libs.springContext
+	testImplementation 'io.projectreactor:reactor-core'
+	testImplementation 'io.projectreactor:reactor-core-micrometer'
 }
 
 antora {

--- a/docs/modules/ROOT/examples/integration-src
+++ b/docs/modules/ROOT/examples/integration-src
@@ -1,0 +1,1 @@
+../../../../micrometer-tracing-tests/micrometer-tracing-integration-test

--- a/docs/modules/ROOT/pages/configuring.adoc
+++ b/docs/modules/ROOT/pages/configuring.adoc
@@ -48,7 +48,22 @@ In order to make https://micrometer.io/docs/contextPropagation[Context Propagati
 
 [source,java,subs=+attributes]
 -----
-include::{include-java}/tracing/TracingConfiguringTests.java[tags=span_thread_local_accessor,indent=0]
+include::{include-java}/tracing/TracingConfiguringTests.java[tags=thread_local_accessors,indent=0]
+-----
+
+The `ObservationAwareSpanThreadLocalAccessor` is required to propagate manually created spans (not the ones that are governed by Observations). The `ObservationAwareBaggageThreadLocalAccessor` is required to propagate baggage created by the user.
+
+With Project Reactor one should set the values of `Observation`, `Span` or `BaggageToPropagate` in the Reactor Context as presented below.
+
+[source,java,subs=+attributes]
+-----
+// Setup example
+include::{include-integration-tests}/src/test/java/io/micrometer/tracing/test/contextpropagation/AbstractObservationAwareSpanThreadLocalAccessorTests.java[tags=setup,indent=0]
+
+include::{include-integration-tests}/src/test/java/io/micrometer/tracing/test/contextpropagation/AbstractObservationAwareSpanThreadLocalAccessorTests.java[tags=setup_accessors,indent=0]
+
+// Usage example
+include::{include-integration-tests}/src/test/java/io/micrometer/tracing/test/contextpropagation/AbstractObservationAwareSpanThreadLocalAccessorTests.java[tags=docs,indent=0]
 -----
 
 === Exemplars

--- a/docs/src/test/java/io/micrometer/docs/tracing/TracingConfiguringTests.java
+++ b/docs/src/test/java/io/micrometer/docs/tracing/TracingConfiguringTests.java
@@ -23,6 +23,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.contextpropagation.ObservationAwareBaggageThreadLocalAccessor;
 import io.micrometer.tracing.contextpropagation.ObservationAwareSpanThreadLocalAccessor;
 import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
 import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
@@ -107,12 +108,16 @@ class TracingConfiguringTests {
 
     void example_of_setting_ObservationAwareSpanThreadLocalAccessor() {
         Tracer tracer = null;
+        ObservationRegistry registry = ObservationRegistry.create();
 
-        // tag::span_thread_local_accessor[]
+        // tag::thread_local_accessors[]
         ContextRegistry.getInstance().registerThreadLocalAccessor(new ObservationAwareSpanThreadLocalAccessor(tracer));
-        // end::span_thread_local_accessor[]
+        ContextRegistry.getInstance()
+            .registerThreadLocalAccessor(new ObservationAwareBaggageThreadLocalAccessor(registry, tracer));
+        // end::thread_local_accessors[]
 
         ContextRegistry.getInstance().removeThreadLocalAccessor(ObservationAwareSpanThreadLocalAccessor.KEY);
+        ContextRegistry.getInstance().removeThreadLocalAccessor(ObservationAwareBaggageThreadLocalAccessor.KEY);
     }
 
     void example_of_exemplars() {

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageInScope.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageInScope.java
@@ -43,6 +43,8 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
 
     private final List<String> tagFields;
 
+    // Null TC would happen pretty much in exceptional cases (there was no span in scope)
+    // but someone wanted to set baggage
     @Nullable
     private brave.propagation.TraceContext traceContext;
 
@@ -79,13 +81,13 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
         if (this.traceContext != null) {
             boolean success = this.delegate.updateValue(this.traceContext, value);
             if (logger.isTraceEnabled()) {
-                logger.trace("Managed to update the baggage on set [" + success + "]");
+                logger.trace("Managed to update the baggage on set [" + success + "]. Provided value [" + value + "]");
             }
         }
         else {
             boolean success = this.delegate.updateValue(value);
             if (logger.isTraceEnabled()) {
-                logger.trace("Managed to update the baggage on set [" + success + "]");
+                logger.trace("Managed to update the baggage on set [" + success + "]. Provided value [" + value + "]");
             }
         }
         tagSpanIfOnTagList();
@@ -107,7 +109,8 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
         brave.propagation.TraceContext braveContext = updateBraveTraceContext(traceContext);
         boolean success = this.delegate.updateValue(braveContext, value);
         if (logger.isTraceEnabled()) {
-            logger.trace("Managed to update the baggage on set [" + success + "]");
+            logger.trace("Managed to update the baggage on set [" + success + "]. Provided value [" + value
+                    + "], trace context [" + traceContext + "]");
         }
         tagSpanIfOnTagList();
         return this;
@@ -152,7 +155,8 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
         brave.propagation.TraceContext braveContext = updateBraveTraceContext(traceContext);
         boolean success = this.delegate.updateValue(braveContext, value);
         if (logger.isTraceEnabled()) {
-            logger.trace("Managed to update the baggage on close [" + success + "]");
+            logger.trace("Managed to update the baggage on close [" + success + "]. Provided value [" + value
+                    + "], trace context [" + traceContext + "]");
         }
         tagSpanIfOnTagList();
         return makeCurrent();

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageInScope.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageInScope.java
@@ -53,7 +53,7 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
             @Nullable Span span, List<String> tagFields) {
         this.delegate = delegate;
         this.traceContext = traceContext;
-        this.previousBaggage = delegate.getValue();
+        this.previousBaggage = traceContext != null ? delegate.getValue(traceContext) : delegate.getValue();
         this.tagFields = tagFields;
         this.span = span;
     }
@@ -77,10 +77,16 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
     @Deprecated
     public Baggage set(String value) {
         if (this.traceContext != null) {
-            this.delegate.updateValue(this.traceContext, value);
+            boolean success = this.delegate.updateValue(this.traceContext, value);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Managed to update the baggage on set [" + success + "]");
+            }
         }
         else {
-            this.delegate.updateValue(value);
+            boolean success = this.delegate.updateValue(value);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Managed to update the baggage on set [" + success + "]");
+            }
         }
         tagSpanIfOnTagList();
         return this;
@@ -99,7 +105,10 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
     @Deprecated
     public Baggage set(TraceContext traceContext, String value) {
         brave.propagation.TraceContext braveContext = updateBraveTraceContext(traceContext);
-        this.delegate.updateValue(braveContext, value);
+        boolean success = this.delegate.updateValue(braveContext, value);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Managed to update the baggage on set [" + success + "]");
+        }
         tagSpanIfOnTagList();
         return this;
     }
@@ -123,10 +132,16 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
     @Override
     public BaggageInScope makeCurrent(String value) {
         if (this.traceContext != null) {
-            this.delegate.updateValue(this.traceContext, value);
+            boolean success = this.delegate.updateValue(this.traceContext, value);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Managed to update the baggage on make current [" + success + "]");
+            }
         }
         else {
-            this.delegate.updateValue(value);
+            boolean success = this.delegate.updateValue(value);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Managed to update the baggage on make current [" + success + "]");
+            }
         }
         tagSpanIfOnTagList();
         return makeCurrent();
@@ -135,7 +150,10 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
     @Override
     public BaggageInScope makeCurrent(TraceContext traceContext, String value) {
         brave.propagation.TraceContext braveContext = updateBraveTraceContext(traceContext);
-        this.delegate.updateValue(braveContext, value);
+        boolean success = this.delegate.updateValue(braveContext, value);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Managed to update the baggage on close [" + success + "]");
+        }
         tagSpanIfOnTagList();
         return makeCurrent();
     }
@@ -143,8 +161,17 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
     @Override
     public void close() {
         if (this.traceContext != null) {
-            this.delegate.updateValue(this.traceContext, this.previousBaggage);
+            boolean success = this.delegate.updateValue(this.traceContext, this.previousBaggage);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Managed to update the baggage on close [" + success + "]");
+            }
         }
+    }
+
+    @Override
+    public String toString() {
+        return "BraveBaggageInScope{" + "delegate=" + delegate + ", previousBaggage='" + previousBaggage + '\''
+                + ", tagFields=" + tagFields + ", traceContext=" + traceContext + ", span=" + span + '}';
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageManager.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageManager.java
@@ -18,10 +18,8 @@ package io.micrometer.tracing.brave.bridge;
 import brave.Span;
 import brave.Tracing;
 import brave.baggage.BaggageField;
-import io.micrometer.tracing.Baggage;
-import io.micrometer.tracing.BaggageInScope;
-import io.micrometer.tracing.BaggageManager;
-import io.micrometer.tracing.TraceContext;
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.tracing.*;
 
 import java.io.Closeable;
 import java.util.Collections;
@@ -37,6 +35,9 @@ import java.util.Map;
 public class BraveBaggageManager implements Closeable, BaggageManager {
 
     private final List<String> tagFields;
+
+    @Nullable
+    private Tracer tracer;
 
     /**
      * Create an instance of {@link BraveBaggageManager}.
@@ -101,7 +102,11 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
     }
 
     // Taken from BraveField
-    private static Span currentSpan() {
+    private Span currentSpan() {
+        if (tracer != null) {
+            io.micrometer.tracing.Span span = tracer.currentSpan();
+            return BraveSpan.toBrave(span);
+        }
         Tracing tracing = Tracing.current();
         return tracing != null ? tracing.tracer().currentSpan() : null;
     }
@@ -125,6 +130,10 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
     @Override
     public void close() {
         // We used to cache baggage fields
+    }
+
+    void setTracer(Tracer tracer) {
+        this.tracer = tracer;
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTracer.java
@@ -44,6 +44,9 @@ public class BraveTracer implements Tracer {
         this.tracer = tracer;
         this.braveBaggageManager = braveBaggageManager;
         this.currentTraceContext = context;
+        if (braveBaggageManager instanceof BraveBaggageManager) {
+            ((BraveBaggageManager) braveBaggageManager).setTracer(this);
+        }
     }
 
     /**

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageInScope.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageInScope.java
@@ -198,4 +198,9 @@ class OtelBaggageInScope implements io.micrometer.tracing.Baggage, BaggageInScop
         }
     }
 
+    @Override
+    public String toString() {
+        return "OtelBaggageInScope{" + "tagFields=" + tagFields + ", entry=" + entry + '}';
+    }
+
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
@@ -15,19 +15,11 @@
  */
 package io.micrometer.tracing.otel.bridge;
 
-import java.util.Map;
-
-import io.micrometer.tracing.Baggage;
-import io.micrometer.tracing.BaggageInScope;
-import io.micrometer.tracing.BaggageManager;
-import io.micrometer.tracing.CurrentTraceContext;
-import io.micrometer.tracing.ScopedSpan;
-import io.micrometer.tracing.Span;
-import io.micrometer.tracing.SpanCustomizer;
-import io.micrometer.tracing.TraceContext;
-import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.*;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+
+import java.util.Map;
 
 /**
  * OpenTelemetry implementation of a {@link Tracer}.
@@ -124,6 +116,9 @@ public class OtelTracer implements Tracer {
     public Span currentSpan() {
         OtelTraceContext context = (OtelTraceContext) this.otelCurrentTraceContext.context();
         if (context != null && context.span != null) {
+            if (io.opentelemetry.api.trace.Span.getInvalid().equals(context.span)) {
+                return null;
+            }
             return new OtelSpan(context);
         }
         io.opentelemetry.api.trace.Span currentSpan = io.opentelemetry.api.trace.Span.current();

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/build.gradle
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	testImplementation libs.wiremock
 	testImplementation libs.awaitility
 	testImplementation libs.logback
+	testImplementation 'io.projectreactor:reactor-core'
 	testImplementation 'org.testcontainers:testcontainers'
 	testImplementation 'org.testcontainers:junit-jupiter'
 }

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/java/io/micrometer/tracing/contextpropagation/TestBaggageThreadLocalAccessor.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/java/io/micrometer/tracing/contextpropagation/TestBaggageThreadLocalAccessor.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 public class TestBaggageThreadLocalAccessor {
 
-    public static Map<Thread, ? extends Object> baggageInScope(BaggageThreadLocalAccessor accessor) {
+    public static Map<Thread, ? extends Object> baggageInScope(ObservationAwareBaggageThreadLocalAccessor accessor) {
         return accessor.baggageInScope;
     }
 

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/java/io/micrometer/tracing/contextpropagation/TestBaggageThreadLocalAccessor.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/java/io/micrometer/tracing/contextpropagation/TestBaggageThreadLocalAccessor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.contextpropagation;
+
+import java.util.Map;
+
+public class TestBaggageThreadLocalAccessor {
+
+    public static Map<Thread, ? extends Object> baggageInScope(BaggageThreadLocalAccessor accessor) {
+        return accessor.baggageInScope;
+    }
+
+}

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/java/io/micrometer/tracing/test/contextpropagation/ObservationAwareSpanThreadLocalAccessorTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/java/io/micrometer/tracing/test/contextpropagation/ObservationAwareSpanThreadLocalAccessorTests.java
@@ -66,6 +66,11 @@ class ObservationAwareSpanThreadLocalAccessorTests {
             Assumptions.assumeFalse(true, "Simple tracer doesn't support baggage propagation");
         }
 
+        @Override
+        void onlyReactorPropagatesBaggageForDocs() {
+            Assumptions.assumeFalse(true, "Simple tracer doesn't support baggage propagation");
+        }
+
     }
 
     @Nested

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/java/io/micrometer/tracing/test/contextpropagation/ObservationAwareSpanThreadLocalAccessorTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/java/io/micrometer/tracing/test/contextpropagation/ObservationAwareSpanThreadLocalAccessorTests.java
@@ -58,16 +58,12 @@ class ObservationAwareSpanThreadLocalAccessorTests {
 
         @Override
         void onlyReactorPropagatesBaggage(boolean threadHopAfterBaggageSet) {
-            Assumptions.assumeFalse(true, "Simple tracer doesn't support baggage propagation"); // TODO:
-                                                                                                // I
-                                                                                                // can't
-                                                                                                // disable
-                                                                                                // this
+            Assumptions.assumeFalse(true, "Simple tracer doesn't support baggage propagation");
         }
 
         @Override
         void onlyReactorPropagatesBaggageWithContextCapture() {
-            super.onlyReactorPropagatesBaggageWithContextCapture();
+            Assumptions.assumeFalse(true, "Simple tracer doesn't support baggage propagation");
         }
 
     }

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/resources/logback.xml
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/resources/logback.xml
@@ -1,0 +1,30 @@
+<!--
+
+    Copyright 2024 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are  by default assigned the type
+			 ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="trace">
+		<appender-ref ref="STDOUT"/>
+	</root>
+</configuration>

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java
@@ -109,12 +109,12 @@ public class SimpleBaggageManager implements BaggageManager {
         TraceContext current = simpleTracer.currentTraceContext().context();
         SimpleBaggageInScope baggage = baggageForName(current, name);
         if (baggage == null) {
+            ThreadLocal<Set<SimpleBaggageInScope>> baggages = this.baggagesByContext.getOrDefault(current,
+                    ThreadLocal.withInitial(HashSet::new));
             baggage = new SimpleBaggageInScope(simpleTracer.currentTraceContext(), name, current);
+            baggages.get().add(baggage);
+            this.baggagesByContext.put(current, baggages);
         }
-        ThreadLocal<Set<SimpleBaggageInScope>> baggages = this.baggagesByContext.getOrDefault(current,
-                ThreadLocal.withInitial(HashSet::new));
-        baggages.get().add(baggage);
-        this.baggagesByContext.put(current, baggages);
         return baggage;
     }
 

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java
@@ -61,6 +61,7 @@ public class SimpleBaggageManager implements BaggageManager {
             .getOrDefault(context, ThreadLocal.withInitial(Collections::emptySet))
             .get()
             .stream()
+            .filter(s -> s.get(context) != null)
             .collect(Collectors.toMap(Baggage::name, baggage -> baggage.get(context)));
         map.putAll(((SimpleTraceContext) context).baggageFromParent());
         return map;

--- a/micrometer-tracing/build.gradle
+++ b/micrometer-tracing/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
 	// exemplars support
 	optionalApi 'io.micrometer:micrometer-core'
+	optionalApi 'io.projectreactor:reactor-core'
 
 	// log monitoring
 	optionalApi libs.logback

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/BaggageThreadLocalAccessor.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/BaggageThreadLocalAccessor.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.contextpropagation;
+
+import io.micrometer.common.lang.NonNull;
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import io.micrometer.context.ThreadLocalAccessor;
+import io.micrometer.tracing.BaggageInScope;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.Tracer.SpanInScope;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * {@link ThreadLocalAccessor} used to propagate baggage via {@link BaggageToPropagate}.
+ *
+ * @since 1.2.2
+ * @author Marcin Grzejszczak
+ */
+public class BaggageThreadLocalAccessor implements ThreadLocalAccessor<BaggageToPropagate> {
+
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(BaggageThreadLocalAccessor.class);
+
+    final Map<Thread, BaggageAndScope> baggageInScope = new ConcurrentHashMap<>();
+
+    /**
+     * Key under which Micrometer Tracing Baggage accessor is being registered.
+     */
+    public static final String KEY = "micrometer.tracing.baggage";
+
+    private final Tracer tracer;
+
+    /**
+     * Creates a new instance of this class.
+     * @param tracer tracer
+     * @since 1.2.2
+     */
+    public BaggageThreadLocalAccessor(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public Object key() {
+        return KEY;
+    }
+
+    @Override
+    public BaggageToPropagate getValue() {
+        Map<String, String> baggage = tracer.getAllBaggage();
+        if (log.isTraceEnabled()) {
+            log.trace("Current baggage in thread local [" + baggageInScope.get(Thread.currentThread())
+                    + "], current baggage from tracer [" + baggage + "]");
+        }
+        return (baggage == null || baggage.isEmpty()) ? null : new BaggageToPropagate(baggage);
+    }
+
+    @Override
+    public void setValue(BaggageToPropagate value) {
+        BaggageAndScope previousConsumer = baggageInScope.get(Thread.currentThread());
+        if (log.isTraceEnabled()) {
+            log.trace("Baggage to set [" + value + "]. Previous consumer [" + previousConsumer + "]");
+        }
+        BaggageAndScope consumer = null;
+        Map<String, String> storedMap = value.getBaggage();
+        Set<Entry<String, String>> entries = storedMap.entrySet();
+        Span span = tracer.currentSpan();
+        if (span == null) {
+            log.warn("There is no span to which we can attach baggage, will not set baggage");
+            return;
+        }
+        consumer = openConsumerForEachBaggageEntry(entries, span, consumer);
+        baggageInScope.put(Thread.currentThread(), scopeRestoringBaggageAndScope(consumer, previousConsumer));
+        if (log.isTraceEnabled()) {
+            log.trace("Finished setting value [" + baggageInScope.get(Thread.currentThread()) + "]");
+        }
+    }
+
+    private BaggageAndScope openConsumerForEachBaggageEntry(Set<Entry<String, String>> entries, Span span,
+            BaggageAndScope consumer) {
+        for (Entry<String, String> entry : entries) {
+            String previousBaggage = tracer.getBaggage(entry.getKey()).get();
+            if (log.isTraceEnabled()) {
+                log.trace("Current span [" + span + "], previous baggage [" + previousBaggage + "]");
+            }
+            BaggageInScope baggage = tracer.createBaggageInScope(span.context(), entry.getKey(), entry.getValue());
+            if (log.isTraceEnabled()) {
+                String storedBaggage = tracer.getBaggage(entry.getKey()).get();
+                log.trace("New baggage [" + baggage + " ] hashcode [" + baggage.hashCode() + "]. Entry to set ["
+                        + entry.getValue() + "] already stored value [" + storedBaggage + "]");
+            }
+            consumer = baggageScopeClosingConsumer(entry, consumer, baggage);
+        }
+        return consumer;
+    }
+
+    @NonNull
+    private static BaggageAndScope baggageScopeClosingConsumer(Entry<String, String> entry, BaggageAndScope consumer,
+            BaggageInScope baggage) {
+        if (consumer == null) {
+            return scopeClosingBaggageAndScope(entry, baggage);
+        }
+        return consumer.andThen(scopeClosingBaggageAndScope(entry, baggage));
+    }
+
+    private static BaggageAndScope scopeClosingBaggageAndScope(Entry<String, String> entry, BaggageInScope baggage) {
+        return new BaggageAndScope(bs -> {
+            if (log.isTraceEnabled()) {
+                log.trace("Closing baggage [" + baggage + "] hashcode [" + baggage.hashCode() + "]");
+            }
+            baggage.close();
+        }, entry);
+    }
+
+    @Override
+    public void setValue() {
+        BaggageAndScope previousConsumer = baggageInScope.get(Thread.currentThread());
+        if (log.isTraceEnabled()) {
+            log.trace("setValue no args, current baggage scope [" + baggageInScope.get(Thread.currentThread()) + "]");
+        }
+        SpanInScope spanInScope = tracer.withSpan(null);
+        BaggageAndScope currentConsumer = new BaggageAndScope(o -> spanInScope.close());
+        baggageInScope.put(Thread.currentThread(), scopeRestoringBaggageAndScope(currentConsumer, previousConsumer));
+        if (log.isTraceEnabled()) {
+            log.trace("setValue no args finished, current baggage scope [" + baggageInScope.get(Thread.currentThread())
+                    + "]");
+        }
+    }
+
+    private BaggageAndScope scopeRestoringBaggageAndScope(BaggageAndScope currentConsumer,
+            BaggageAndScope previousConsumer) {
+        return currentConsumer.andThen(o -> {
+            if (previousConsumer != null) {
+                baggageInScope.put(Thread.currentThread(), previousConsumer);
+            }
+            else {
+                baggageInScope.remove(Thread.currentThread());
+            }
+        });
+    }
+
+    private void closeCurrentScope() {
+        BaggageAndScope consumer = baggageInScope.get(Thread.currentThread());
+        if (log.isTraceEnabled()) {
+            log.trace("Before close scope [" + baggageInScope.get(Thread.currentThread()) + "]");
+        }
+        if (consumer != null) {
+            consumer.accept(null);
+        }
+        if (log.isTraceEnabled()) {
+            log.trace("After close scope [" + baggageInScope.get(Thread.currentThread()) + "]");
+        }
+    }
+
+    @Override
+    public void restore() {
+        if (log.isTraceEnabled()) {
+            log.trace("Calling restore()");
+        }
+        closeCurrentScope();
+    }
+
+    @Override
+    public void restore(BaggageToPropagate value) {
+        if (log.isTraceEnabled()) {
+            log.trace("Calling restore(Map)");
+        }
+        closeCurrentScope();
+    }
+
+    @Override
+    @Deprecated
+    public void reset() {
+        if (log.isTraceEnabled()) {
+            log.trace("Calling reset()");
+        }
+        ThreadLocalAccessor.super.reset();
+    }
+
+    static class BaggageAndScope implements Consumer<Object> {
+
+        private static final InternalLogger log = InternalLoggerFactory.getInstance(BaggageInScope.class);
+
+        private final Consumer<Object> consumer;
+
+        private final Entry<String, String> entry;
+
+        BaggageAndScope(Consumer<Object> consumer, Entry<String, String> entry) {
+            this.consumer = consumer;
+            this.entry = entry;
+        }
+
+        BaggageAndScope(Consumer<Object> consumer) {
+            this.consumer = consumer;
+            this.entry = null;
+        }
+
+        @Override
+        public String toString() {
+            return "BaggageAndScope{" + "consumer=" + consumer + ", entry=" + entry + '}';
+        }
+
+        @Override
+        public void accept(Object o) {
+            if (log.isTraceEnabled()) {
+                log.trace("Accepting consumer [" + this + "]");
+            }
+            this.consumer.accept(o);
+        }
+
+        @NonNull
+        @Override
+        public BaggageAndScope andThen(@NonNull Consumer<? super Object> after) {
+            return new BaggageAndScope(Consumer.super.andThen(after), entry);
+        }
+
+    }
+
+}

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/BaggageToPropagate.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/BaggageToPropagate.java
@@ -15,20 +15,22 @@
  */
 package io.micrometer.tracing.contextpropagation;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Wrapper around baggage to propagate.
  *
- * @since 1.2.2
  * @author Marcin Grzejszczak
+ * @since 1.2.2
  */
 public class BaggageToPropagate {
 
     private final Map<String, String> baggage;
 
     public BaggageToPropagate(Map<String, String> baggage) {
-        this.baggage = baggage;
+        this.baggage = new HashMap<>(baggage);
     }
 
     public Map<String, String> getBaggage() {
@@ -38,6 +40,23 @@ public class BaggageToPropagate {
     @Override
     public String toString() {
         return "BaggageToPropagate{" + "baggage=" + baggage + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BaggageToPropagate that = (BaggageToPropagate) o;
+        return Objects.equals(baggage, that.baggage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(baggage);
     }
 
 }

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/BaggageToPropagate.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/BaggageToPropagate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.contextpropagation;
+
+import java.util.Map;
+
+/**
+ * Wrapper around baggage to propagate.
+ *
+ * @since 1.2.2
+ * @author Marcin Grzejszczak
+ */
+public class BaggageToPropagate {
+
+    private final Map<String, String> baggage;
+
+    public BaggageToPropagate(Map<String, String> baggage) {
+        this.baggage = baggage;
+    }
+
+    public Map<String, String> getBaggage() {
+        return baggage;
+    }
+
+    @Override
+    public String toString() {
+        return "BaggageToPropagate{" + "baggage=" + baggage + '}';
+    }
+
+}

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/BaggageToPropagate.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/BaggageToPropagate.java
@@ -29,8 +29,30 @@ public class BaggageToPropagate {
 
     private final Map<String, String> baggage;
 
+    /**
+     * Creates a new instance of {@link BaggageToPropagate} with this baggage.
+     * @param baggage baggage entries
+     */
     public BaggageToPropagate(Map<String, String> baggage) {
         this.baggage = new HashMap<>(baggage);
+    }
+
+    /**
+     * Creates a new instance of {@link BaggageToPropagate} with a single baggage entry.
+     * @param baggage array of baggage key, value pairs (e.g. "foo", "foo1", "foo2",
+     * "foo3" will result in baggage foo:foo1, foo2:foo3
+     */
+    public BaggageToPropagate(String... baggage) {
+        this.baggage = new HashMap<>();
+        if (baggage.length % 2 != 0) {
+            throw new IllegalArgumentException(
+                    "You need an even number of baggage entries. You have [" + baggage.length + "] entries");
+        }
+        for (int i = 1; i < baggage.length; i = i + 2) {
+            String key = baggage[i - 1];
+            String value = baggage[i];
+            this.baggage.put(key, value);
+        }
     }
 
     public Map<String, String> getBaggage() {

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/ObservationAwareSpanThreadLocalAccessor.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/ObservationAwareSpanThreadLocalAccessor.java
@@ -15,8 +15,6 @@
  */
 package io.micrometer.tracing.contextpropagation;
 
-import io.micrometer.common.lang.NonNull;
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.context.ContextRegistry;
@@ -24,20 +22,15 @@ import io.micrometer.context.ThreadLocalAccessor;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
-import io.micrometer.tracing.BaggageInScope;
 import io.micrometer.tracing.Span;
-import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.Tracer;
-import io.micrometer.tracing.Tracer.SpanInScope;
 import io.micrometer.tracing.handler.TracingObservationHandler;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 /**
  * A {@link ThreadLocalAccessor} to put and restore current {@link Span} depending on
@@ -104,106 +97,78 @@ public class ObservationAwareSpanThreadLocalAccessor implements ThreadLocalAcces
     @Override
     public Span getValue() {
         Observation currentObservation = registry.getCurrentObservation();
+        Span currentSpan = tracer.currentSpan();
         if (currentObservation != null) {
             // There's a current observation so OTLA hooked in
             // we will now check if the user created spans manually or not
             TracingObservationHandler.TracingContext tracingContext = currentObservation.getContext()
                 .getOrDefault(TracingObservationHandler.TracingContext.class,
                         new TracingObservationHandler.TracingContext());
-            Span currentSpan = tracer.currentSpan();
             // If there is a span in ThreadLocal and it's the same one as the one from a
             // tracing handler
             // then OTLA did its job and we should back off
             if (currentSpan != null && !currentSpan.equals(tracingContext.getSpan())) {
                 // User created child spans manually and scoped them
                 // the current span is not the same as the one from observation
-                return new SpanWithBaggage(this.tracer, currentSpan);
+                if (log.isTraceEnabled()) {
+                    log.trace("User created child spans manually and scoped them, returning [" + currentSpan + "]");
+                }
+                return currentSpan;
+            }
+            if (log.isTraceEnabled()) {
+                log.trace("Span created by OTLA, falling back to [null]");
             }
             return null;
         }
-        Span span = tracer.currentSpan();
-        if (span == null) {
-            return span;
+        if (log.isTraceEnabled()) {
+            log.trace("No span created by OTLA, retrieving current span from tracer [" + currentSpan + "]");
         }
-        return new SpanWithBaggage(this.tracer, span);
+        return currentSpan;
     }
 
     @Override
     public void setValue(Span value) {
-        SpanAction spanAction = spanActions.get(Thread.currentThread());
-        Tracer.SpanInScope scope;
-        if (value instanceof SpanWithBaggage) {
-            scope = this.tracer.withSpan(((SpanWithBaggage) value).delegate);
+        if (log.isTraceEnabled()) {
+            log.trace("Setting value [" + value + "], current span [" + tracer.currentSpan() + "]");
         }
-        else {
-            scope = this.tracer.withSpan(value);
+        SpanAction spanAction = spanActions.get(Thread.currentThread());
+        Tracer.SpanInScope scope = this.tracer.withSpan(value);
+        if (log.isTraceEnabled()) {
+            log.trace("New scope created [" + scope + "], current span [" + value + "]");
         }
         SpanAction newSpanAction = new SpanAction(spanActions, spanAction);
         spanActions.put(Thread.currentThread(), newSpanAction);
-        Consumer<?> consumer = null;
-        if (value instanceof SpanWithBaggage) {
-            consumer = createNewScopesForAllPreviouslyStoredBaggage(value, consumer, scope);
-        }
-        else {
-            consumer = o -> scope.close();
-        }
-        newSpanAction.setScope(consumer);
-    }
-
-    private Consumer<?> createNewScopesForAllPreviouslyStoredBaggage(Span value, Consumer<?> consumer,
-            SpanInScope scope) {
-        TraceContext context = value.context();
-        SpanWithBaggage spanWithBaggage = (SpanWithBaggage) value;
-        Map<String, String> storedBaggage = spanWithBaggage.baggage;
-        for (Entry<String, String> entry : storedBaggage.entrySet()) {
-            consumer = appendBaggageScopeClosing(entry, context, consumer);
-        }
-        return appendSpanScopeClosing(consumer, scope);
-    }
-
-    private Consumer<?> appendBaggageScopeClosing(Entry<String, String> entry, TraceContext context,
-            @Nullable Consumer<?> consumer) {
-        String baggageKey = entry.getKey();
-        String baggageValue = entry.getValue();
-        BaggageInScope baggageInScope = this.tracer.createBaggageInScope(context, baggageKey, baggageValue);
-        if (consumer == null) {
-            // first pass
-            return o -> baggageInScope.close();
-        }
-        return consumer.andThen(o -> baggageInScope.close());
-    }
-
-    private static Consumer<?> appendSpanScopeClosing(Consumer<?> consumer, SpanInScope scope) {
-        if (consumer != null) {
-            return consumer.andThen(o -> scope.close());
-        }
-        // no baggage was present
-        return o -> scope.close();
+        newSpanAction.setScope(scope);
     }
 
     @Override
     public void setValue() {
+        if (log.isTraceEnabled()) {
+            log.trace("Setting null value, current span [" + tracer.currentSpan() + "]");
+        }
         SpanAction spanAction = spanActions.get(Thread.currentThread());
         if (spanAction == null) {
             return;
         }
         Tracer.SpanInScope scope = this.tracer.withSpan(null);
-        Consumer<?> consumer = o -> scope.close();
-        spanAction.setScope(consumer);
+        if (log.isTraceEnabled()) {
+            log.trace("Null scope created");
+        }
+        spanAction.setScope(scope);
     }
 
     @Override
     public void restore(Span previousValue) {
+        if (log.isTraceEnabled()) {
+            log.trace("Restoring previous value [" + previousValue + "]");
+        }
         SpanAction spanAction = spanActions.get(Thread.currentThread());
         if (spanAction == null) {
             return;
         }
         spanAction.close();
         Span currentSpan = tracer.currentSpan();
-        if (previousValue instanceof SpanWithBaggage) {
-            previousValue = ((SpanWithBaggage) previousValue).delegate;
-        }
-        if (!(Objects.equals(previousValue, currentSpan))) {
+        if (!(previousValue.equals(currentSpan))) {
             String msg = "After closing the scope, current span <" + currentSpan
                     + "> is not the same as the one to which you want to revert <" + previousValue
                     + ">. Most likely you've opened a scope and forgotten to close it";
@@ -214,6 +179,9 @@ public class ObservationAwareSpanThreadLocalAccessor implements ThreadLocalAcces
 
     @Override
     public void restore() {
+        if (log.isTraceEnabled()) {
+            log.trace("Restoring no args");
+        }
         SpanAction spanAction = spanActions.get(Thread.currentThread());
         if (spanAction != null) {
             spanAction.close();
@@ -226,21 +194,26 @@ public class ObservationAwareSpanThreadLocalAccessor implements ThreadLocalAcces
 
         final Map<Thread, SpanAction> todo;
 
-        Consumer<?> scope;
+        Closeable scope;
 
         SpanAction(Map<Thread, SpanAction> spanActions, SpanAction previous) {
             this.previous = previous;
             this.todo = spanActions;
         }
 
-        void setScope(Consumer<?> scope) {
+        void setScope(Closeable scope) {
             this.scope = scope;
         }
 
         @Override
         public void close() {
             if (this.scope != null) {
-                this.scope.accept(null);
+                try {
+                    this.scope.close();
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
             if (this.previous != null) {
                 this.todo.put(Thread.currentThread(), this.previous);
@@ -248,99 +221,6 @@ public class ObservationAwareSpanThreadLocalAccessor implements ThreadLocalAcces
             else {
                 this.todo.remove(Thread.currentThread());
             }
-        }
-
-    }
-
-    static class SpanWithBaggage implements Span {
-
-        private final Span delegate;
-
-        final Map<String, String> baggage;
-
-        SpanWithBaggage(Tracer tracer, @NonNull Span delegate) {
-            this.delegate = delegate;
-            this.baggage = tracer.getAllBaggage(delegate.context());
-        }
-
-        @Override
-        public boolean isNoop() {
-            return this.delegate.isNoop();
-        }
-
-        @Override
-        public TraceContext context() {
-            return this.delegate.context();
-        }
-
-        @Override
-        public Span start() {
-            return this.delegate.start();
-        }
-
-        @Override
-        public Span name(String name) {
-            return this.delegate.name(name);
-        }
-
-        @Override
-        public Span event(String value) {
-            return this.delegate.event(value);
-        }
-
-        @Override
-        public Span event(String value, long time, TimeUnit timeUnit) {
-            return this.delegate.event(value, time, timeUnit);
-        }
-
-        @Override
-        public Span tag(String key, String value) {
-            return this.delegate.tag(key, value);
-        }
-
-        @Override
-        public Span tag(String key, long value) {
-            return this.delegate.tag(key, value);
-        }
-
-        @Override
-        public Span tag(String key, double value) {
-            return this.delegate.tag(key, value);
-        }
-
-        @Override
-        public Span tag(String key, boolean value) {
-            return this.delegate.tag(key, value);
-        }
-
-        @Override
-        public Span error(Throwable throwable) {
-            return this.delegate.error(throwable);
-        }
-
-        @Override
-        public void end() {
-            this.delegate.end();
-        }
-
-        @Override
-        public void end(long time, TimeUnit timeUnit) {
-            this.delegate.end(time, timeUnit);
-        }
-
-        @Override
-        public void abandon() {
-            this.delegate.abandon();
-        }
-
-        @Override
-        public Span remoteServiceName(String remoteServiceName) {
-            return this.delegate.remoteServiceName(remoteServiceName);
-        }
-
-        @Override
-        public Span remoteIpAndPort(String ip, int port) {
-            return this.delegate.remoteIpAndPort(ip, port);
         }
 
     }

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/ObservationAwareSpanThreadLocalAccessor.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/ObservationAwareSpanThreadLocalAccessor.java
@@ -27,7 +27,6 @@ import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.handler.TracingObservationHandler;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -180,7 +179,7 @@ public class ObservationAwareSpanThreadLocalAccessor implements ThreadLocalAcces
     @Override
     public void restore() {
         if (log.isTraceEnabled()) {
-            log.trace("Restoring no args");
+            log.trace("Restoring to empty span scope");
         }
         SpanAction spanAction = spanActions.get(Thread.currentThread());
         if (spanAction != null) {
@@ -188,13 +187,13 @@ public class ObservationAwareSpanThreadLocalAccessor implements ThreadLocalAcces
         }
     }
 
-    static class SpanAction implements Closeable {
+    static class SpanAction implements AutoCloseable {
 
         final SpanAction previous;
 
         final Map<Thread, SpanAction> todo;
 
-        Closeable scope;
+        AutoCloseable scope;
 
         SpanAction(Map<Thread, SpanAction> spanActions, SpanAction previous) {
             this.previous = previous;
@@ -211,7 +210,7 @@ public class ObservationAwareSpanThreadLocalAccessor implements ThreadLocalAcces
                 try {
                     this.scope.close();
                 }
-                catch (IOException e) {
+                catch (Exception e) {
                     throw new RuntimeException(e);
                 }
             }

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/ObservationAwareSpanThreadLocalAccessor.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/ObservationAwareSpanThreadLocalAccessor.java
@@ -147,6 +147,9 @@ public class ObservationAwareSpanThreadLocalAccessor implements ThreadLocalAcces
         }
         SpanAction spanAction = spanActions.get(Thread.currentThread());
         if (spanAction == null) {
+            if (log.isTraceEnabled()) {
+                log.trace("No action to perform");
+            }
             return;
         }
         Tracer.SpanInScope scope = this.tracer.withSpan(null);
@@ -163,6 +166,9 @@ public class ObservationAwareSpanThreadLocalAccessor implements ThreadLocalAcces
         }
         SpanAction spanAction = spanActions.get(Thread.currentThread());
         if (spanAction == null) {
+            if (log.isTraceEnabled()) {
+                log.trace("No action to perform");
+            }
             return;
         }
         spanAction.close();
@@ -184,6 +190,9 @@ public class ObservationAwareSpanThreadLocalAccessor implements ThreadLocalAcces
         SpanAction spanAction = spanActions.get(Thread.currentThread());
         if (spanAction != null) {
             spanAction.close();
+        }
+        else if (log.isTraceEnabled()) {
+            log.trace("No action to perform");
         }
     }
 

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/reactor/ReactorBaggage.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/reactor/ReactorBaggage.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.contextpropagation.reactor;
+
+import io.micrometer.tracing.contextpropagation.ObservationAwareBaggageThreadLocalAccessor;
+import io.micrometer.tracing.contextpropagation.BaggageToPropagate;
+import reactor.util.context.Context;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Helper class to work with Reactor {@link Context} and {@link BaggageToPropagate}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.2.2
+ */
+public final class ReactorBaggage {
+
+    private ReactorBaggage() {
+        throw new IllegalStateException("Can't instantiate a utility class");
+    }
+
+    /**
+     * Appends a single baggage entry to the existing {@link Function}.
+     * @param key baggage key
+     * @param value baggage value
+     * @return function transforming {@link Context} to append the baggage entry to the
+     * existing baggage
+     */
+    public static Function<Context, Context> append(String key, String value) {
+        return context -> append(context, key, value);
+    }
+
+    /**
+     * Appends baggage entries to the existing {@link Function}.
+     * @param baggage baggage entries
+     * @return function transforming {@link Context} to append the baggage entries to the
+     * existing baggage
+     */
+    public static Function<Context, Context> append(Map<String, String> baggage) {
+        return context -> append(context, baggage);
+    }
+
+    private static Context append(Context context, Map<String, String> baggage) {
+        BaggageToPropagate baggageToPropagate = context.getOrDefault(ObservationAwareBaggageThreadLocalAccessor.KEY,
+                null);
+        Map<String, String> mergedBaggage = new HashMap<>(baggage);
+        if (baggageToPropagate != null) {
+            mergedBaggage.putAll(baggageToPropagate.getBaggage());
+        }
+        BaggageToPropagate merged = new BaggageToPropagate(mergedBaggage);
+        return context.put(ObservationAwareBaggageThreadLocalAccessor.KEY, merged);
+    }
+
+    private static Context append(Context context, String key, String value) {
+        BaggageToPropagate baggageToPropagate = context.getOrDefault(ObservationAwareBaggageThreadLocalAccessor.KEY,
+                null);
+        Map<String, String> mergedBaggage = new HashMap<>();
+        mergedBaggage.put(key, value);
+        if (baggageToPropagate != null) {
+            mergedBaggage.putAll(baggageToPropagate.getBaggage());
+        }
+        BaggageToPropagate merged = new BaggageToPropagate(mergedBaggage);
+        return context.put(ObservationAwareBaggageThreadLocalAccessor.KEY, merged);
+    }
+
+}

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
@@ -19,7 +19,6 @@ import io.micrometer.tracing.CurrentTraceContext;
 import io.micrometer.tracing.CurrentTraceContext.Scope;
 import io.micrometer.tracing.handler.TracingObservationHandler.TracingContext;
 
-import java.util.Map;
 import java.util.Objects;
 
 class RevertingScope implements CurrentTraceContext.Scope {
@@ -30,21 +29,16 @@ class RevertingScope implements CurrentTraceContext.Scope {
 
     private final CurrentTraceContext.Scope previousScope;
 
-    private final Map<String, String> previousBaggage;
-
-    RevertingScope(TracingContext tracingContext, Scope currentScope, Scope previousScope,
-            Map<String, String> previousBaggage) {
+    RevertingScope(TracingContext tracingContext, Scope currentScope, Scope previousScope) {
         this.tracingContext = tracingContext;
         this.currentScope = currentScope;
         this.previousScope = previousScope;
-        this.previousBaggage = previousBaggage;
     }
 
     @Override
     public void close() {
         this.currentScope.close();
         this.tracingContext.setScope(this.previousScope);
-        this.tracingContext.setBaggage(this.previousBaggage);
     }
 
     @Override
@@ -62,13 +56,12 @@ class RevertingScope implements CurrentTraceContext.Scope {
         }
         RevertingScope that = (RevertingScope) o;
         return Objects.equals(tracingContext, that.tracingContext) && Objects.equals(currentScope, that.currentScope)
-                && Objects.equals(previousScope, that.previousScope)
-                && Objects.equals(previousBaggage, that.previousBaggage);
+                && Objects.equals(previousScope, that.previousScope);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tracingContext, currentScope, previousScope, previousBaggage);
+        return Objects.hash(tracingContext, currentScope, previousScope);
     }
 
 }

--- a/micrometer-tracing/src/test/java/io/micrometer/tracing/contextpropagation/BaggageToPropagateTests.java
+++ b/micrometer-tracing/src/test/java/io/micrometer/tracing/contextpropagation/BaggageToPropagateTests.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.micrometer.tracing.contextpropagation;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+
+class BaggageToPropagateTests {
+
+    @Test
+    void should_throw_an_exception_when_even_number_of_args() {
+        thenThrownBy(() -> new BaggageToPropagate("foo")).isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("You need an even number of baggage entries. You have [1] entries");
+    }
+
+    @Test
+    void should_set_baggage_to_propagate_entries_with_a_map() {
+        Map<String, String> map = new HashMap<>();
+        map.put("foo", "bar");
+
+        then(new BaggageToPropagate(map).getBaggage()).containsExactlyEntriesOf(map);
+    }
+
+    @Test
+    void should_set_baggage_to_propagate_entries_with_varrgs() {
+        Map<String, String> map = new HashMap<>();
+        map.put("foo", "bar");
+        map.put("baz", "bar2");
+
+        then(new BaggageToPropagate("foo", "bar", "baz", "bar2").getBaggage()).containsExactlyEntriesOf(map);
+    }
+
+}

--- a/micrometer-tracing/src/test/java/io/micrometer/tracing/handler/TracingObservationHandlerTests.java
+++ b/micrometer-tracing/src/test/java/io/micrometer/tracing/handler/TracingObservationHandlerTests.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.mockito.InOrder;
 
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,9 +61,8 @@ class TracingObservationHandlerTests {
         TracingObservationHandler.TracingContext tracingContext = new TracingObservationHandler.TracingContext();
         CurrentTraceContext.Scope scope1 = mock(CurrentTraceContext.Scope.class);
         CurrentTraceContext.Scope scope2 = mock(CurrentTraceContext.Scope.class);
-        RevertingScope revertingScope1 = new RevertingScope(tracingContext, scope1, null, Collections.emptyMap());
-        RevertingScope revertingScope2 = new RevertingScope(tracingContext, scope2, revertingScope1,
-                Collections.emptyMap());
+        RevertingScope revertingScope1 = new RevertingScope(tracingContext, scope1, null);
+        RevertingScope revertingScope2 = new RevertingScope(tracingContext, scope2, revertingScope1);
         tracingContext.setScope(revertingScope2);
         context.put(TracingObservationHandler.TracingContext.class, tracingContext);
 


### PR DESCRIPTION
previously we've tried to store both baggage and span through TracingObservationHandler. That didn't hold when working with reactive applications because it would require users to create artificial baggage scopes and actually due to scopes getting closed early, we would lose the actual baggage value on the attached TraceContext.

with this change we revert to previous approach where the TOH actually creates a scope for spans only. For context propagation we are treating baggage as a first class citizen that requires its own ThreadLocalAccessor, that's why we create the BaggageThreadLocalAccessor, that should be registered after the ObservationAwareSpanThreadLocalAccessor. With that, in reactive applications, under the BaggageThreadLocalAccessor#KEY users will need to register the BaggageToPropagate in e.g. Reactor Context and then it's up to the Context Propagation library to start and stop scopes.

Additional tasks:

* BraveBaggageManager can have the Micrometer Tracer set on it 
 * BraveTracer automatically sets itself on BBM
 * Current Span will now be resolved from the MT if possible

Related issue - https://github.com/micrometer-metrics/tracing/issues/504
[Usage example](https://github.com/surmabck/spring-boot-3xx-micrometer-issues/compare/micrometer-1.2.1-springboottests-misbehave...marcingrzejszczak:spring-boot-3xx-micrometer-issues:micrometer-1.2.1-springboottests-misbehave?expand=1#diff-1d7ba6836beb2592bae39c9eeac74023dd62d3c8e6790df46303d7418bd68456R30-R32)