### PR TITLE
Upgrade to OTel 1.35.0 and Zipkin dependencies

### DIFF
--- a/docs/src/test/java/io/micrometer/docs/tracing/TracingApiTests.java
+++ b/docs/src/test/java/io/micrometer/docs/tracing/TracingApiTests.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
-import zipkin2.reporter.brave.ZipkinSpanHandler;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 import java.util.Collections;
@@ -110,7 +109,7 @@ class TracingApiTests {
         @AfterEach
         void close() {
             this.tracing.close();
-            ((ZipkinSpanHandler) this.spanHandler).close();
+            this.spanHandler.close();
         }
 
         @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,12 +7,11 @@ jmh="1.37"
 jakartaWeb="9.1.0"
 otelInstrumentation="1.32.1-alpha"
 aopalliance="1.0"
-# TODO: Update to 1.0.0 after https://github.com/open-telemetry/opentelemetry-java/pull/6129
-zipkinAws="0.24.0"
-otelBom="1.34.1"
+zipkinAws="1.2.3"
+otelBom="1.35.0"
 logback = "1.4.14"
 wavefrontSdk="3.4.3"
-otelBomAlpha="1.34.1-alpha"
+otelBomAlpha="1.35.0-alpha"
 log4j = "2.22.1"
 wavefrontReporter="1.7.16"
 slf4j = "1.7.36"
@@ -23,11 +22,7 @@ wiremock = "3.0.1"
 testcontainers = "1.19.5"
 braveBom = "6.0.0"
 bravePropagationW3c = "0.2.0"
-# TODO: Update to 3.1.1 after https://github.com/open-telemetry/opentelemetry-java/pull/6129
-# Then, add an optional bean zipkin2.reporter.BytesEncoder<brave.handler.MutableSpan>
-# When present, use the overload of AsyncZipkinSpanHandler.build, allowing custom formats like
-# OTLP, Wavefront or Stackdriver.
-zipkinReporterBom = "2.17.2"
+zipkinReporterBom = "3.2.1"
 reactorBom = "2022.0.15"
 asmForPlugins = "7.3.1"
 javaFormatForPlugins = "0.0.41"

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/W3CPropagation.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/W3CPropagation.java
@@ -113,7 +113,7 @@ public class W3CPropagation extends Propagation.Factory implements Propagation<S
     }
 
     /**
-     * <h3>This does not set the shared flag when extracting headers</h3>
+     * <strong>This does not set the shared flag when extracting headers</strong>
      *
      * <p>
      * {@link brave.propagation.TraceContext#shared()} is not set here because it is not a

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/SampleTestRunner.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/SampleTestRunner.java
@@ -41,11 +41,11 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import zipkin2.CheckResult;
-import zipkin2.reporter.Sender;
+import zipkin2.reporter.BytesMessageSender;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
@@ -453,10 +453,13 @@ public abstract class SampleTestRunner {
                     + " not found in the list of tracing setups to run " + Arrays.toString(chosenSetups));
         }
 
-        private static void checkZipkinAssumptions(Sender sender) {
-            CheckResult checkResult = sender.check();
-            Assumptions.assumeTrue(checkResult.ok(),
-                    "There was a problem with connecting to Zipkin. Will NOT run any tests");
+        private static void checkZipkinAssumptions(BytesMessageSender sender) {
+            try {
+                sender.send(Collections.emptyList());
+            }
+            catch (Exception e) {
+                Assumptions.abort("There was a problem with connecting to Zipkin. Will NOT run any tests");
+            }
         }
 
         private static void checkWavefrontAssumptions(SampleRunnerConfig sampleRunnerConfig) {

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinBraveSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinBraveSetup.java
@@ -33,7 +33,7 @@ import io.micrometer.tracing.http.HttpClientHandler;
 import io.micrometer.tracing.http.HttpServerHandler;
 import io.micrometer.tracing.propagation.Propagator;
 import io.micrometer.tracing.test.reporter.BuildingBlocks;
-import zipkin2.reporter.Sender;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
@@ -92,9 +92,9 @@ public final class ZipkinBraveSetup implements AutoCloseable {
 
         private String zipkinUrl = "http://localhost:9411";
 
-        private Supplier<Sender> sender;
+        private Supplier<BytesMessageSender> sender;
 
-        private Function<Sender, AsyncZipkinSpanHandler> spanHandler;
+        private Function<BytesMessageSender, AsyncZipkinSpanHandler> spanHandler;
 
         private Function<AsyncZipkinSpanHandler, Tracing> tracing;
 
@@ -119,7 +119,7 @@ public final class ZipkinBraveSetup implements AutoCloseable {
          */
         public static class BraveBuildingBlocks implements BuildingBlocks {
 
-            private final Sender sender;
+            private final BytesMessageSender sender;
 
             private final AsyncZipkinSpanHandler spanHandler;
 
@@ -154,7 +154,7 @@ public final class ZipkinBraveSetup implements AutoCloseable {
              * @param customizers observation handler customizers
              * @param testSpanHandler test span handler
              */
-            public BraveBuildingBlocks(Sender sender, AsyncZipkinSpanHandler spanHandler, Tracing tracing,
+            public BraveBuildingBlocks(BytesMessageSender sender, AsyncZipkinSpanHandler spanHandler, Tracing tracing,
                     Tracer tracer, BravePropagator propagator, HttpTracing httpTracing,
                     HttpServerHandler httpServerHandler, HttpClientHandler httpClientHandler,
                     BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizers,
@@ -175,7 +175,7 @@ public final class ZipkinBraveSetup implements AutoCloseable {
              * Returns the sender.
              * @return sender
              */
-            public Sender getSender() {
+            public BytesMessageSender getSender() {
                 return sender;
             }
 
@@ -251,7 +251,7 @@ public final class ZipkinBraveSetup implements AutoCloseable {
          * @param sender sender provider
          * @return this for chaining
          */
-        public Builder sender(Supplier<Sender> sender) {
+        public Builder sender(Supplier<BytesMessageSender> sender) {
             this.sender = sender;
             return this;
         }
@@ -261,7 +261,7 @@ public final class ZipkinBraveSetup implements AutoCloseable {
          * @param spanHandler spanHandler provider
          * @return this for chaining
          */
-        public Builder spanHandler(Function<Sender, AsyncZipkinSpanHandler> spanHandler) {
+        public Builder spanHandler(Function<BytesMessageSender, AsyncZipkinSpanHandler> spanHandler) {
             this.spanHandler = spanHandler;
             return this;
         }
@@ -359,7 +359,7 @@ public final class ZipkinBraveSetup implements AutoCloseable {
          * @return setup with all Brave building blocks
          */
         public ZipkinBraveSetup register(ObservationRegistry registry) {
-            Sender sender = this.sender != null ? this.sender.get() : sender(this.zipkinUrl);
+            BytesMessageSender sender = this.sender != null ? this.sender.get() : sender(this.zipkinUrl);
             AsyncZipkinSpanHandler spanHandler = this.spanHandler != null ? this.spanHandler.apply(sender)
                     : spanHandler(sender);
             TestSpanHandler testSpanHandler = new TestSpanHandler();
@@ -388,7 +388,7 @@ public final class ZipkinBraveSetup implements AutoCloseable {
             return new ZipkinBraveSetup(closingFunction, braveBuildingBlocks);
         }
 
-        private static Sender sender(String zipkinUrl) {
+        private static BytesMessageSender sender(String zipkinUrl) {
             return URLConnectionSender.newBuilder()
                 .connectTimeout(1000)
                 .readTimeout(1000)
@@ -397,7 +397,7 @@ public final class ZipkinBraveSetup implements AutoCloseable {
                 .build();
         }
 
-        private static AsyncZipkinSpanHandler spanHandler(Sender sender) {
+        private static AsyncZipkinSpanHandler spanHandler(BytesMessageSender sender) {
             return AsyncZipkinSpanHandler.create(sender);
         }
 

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinOtelSetup.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/main/java/io/micrometer/tracing/test/reporter/zipkin/ZipkinOtelSetup.java
@@ -38,7 +38,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.semconv.ResourceAttributes;
-import zipkin2.reporter.Sender;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 import java.util.Collections;
@@ -97,9 +97,9 @@ public final class ZipkinOtelSetup implements AutoCloseable {
 
         private String zipkinUrl = "http://localhost:9411";
 
-        private Supplier<Sender> sender;
+        private Supplier<BytesMessageSender> sender;
 
-        private Function<Sender, ZipkinSpanExporter> zipkinSpanExporter;
+        private Function<BytesMessageSender, ZipkinSpanExporter> zipkinSpanExporter;
 
         private Function<ZipkinSpanExporter, SdkTracerProvider> sdkTracerProvider;
 
@@ -126,7 +126,7 @@ public final class ZipkinOtelSetup implements AutoCloseable {
          */
         public static class OtelBuildingBlocks implements BuildingBlocks {
 
-            private final Sender sender;
+            private final BytesMessageSender sender;
 
             private final ZipkinSpanExporter zipkinSpanExporter;
 
@@ -164,7 +164,7 @@ public final class ZipkinOtelSetup implements AutoCloseable {
              * @param customizers observation customizers
              * @param arrayListSpanProcessor array list span processor
              */
-            public OtelBuildingBlocks(Sender sender, ZipkinSpanExporter zipkinSpanExporter,
+            public OtelBuildingBlocks(BytesMessageSender sender, ZipkinSpanExporter zipkinSpanExporter,
                     SdkTracerProvider sdkTracerProvider, OpenTelemetrySdk openTelemetrySdk, Tracer tracer,
                     OtelTracer otelTracer, OtelPropagator propagator, HttpServerHandler httpServerHandler,
                     HttpClientHandler httpClientHandler,
@@ -185,9 +185,9 @@ public final class ZipkinOtelSetup implements AutoCloseable {
 
             /**
              * Returns a sender.
-             * @return a {@link Sender}
+             * @return a {@link BytesMessageSender}
              */
-            public Sender getSender() {
+            public BytesMessageSender getSender() {
                 return sender;
             }
 
@@ -263,7 +263,7 @@ public final class ZipkinOtelSetup implements AutoCloseable {
          * @param sender sender provider
          * @return this for chaining
          */
-        public Builder sender(Supplier<Sender> sender) {
+        public Builder sender(Supplier<BytesMessageSender> sender) {
             this.sender = sender;
             return this;
         }
@@ -273,7 +273,7 @@ public final class ZipkinOtelSetup implements AutoCloseable {
          * @param zipkinSpanExporter exporter provider
          * @return this for chaining
          */
-        public Builder zipkinSpanExporter(Function<Sender, ZipkinSpanExporter> zipkinSpanExporter) {
+        public Builder zipkinSpanExporter(Function<BytesMessageSender, ZipkinSpanExporter> zipkinSpanExporter) {
             this.zipkinSpanExporter = zipkinSpanExporter;
             return this;
         }
@@ -381,7 +381,7 @@ public final class ZipkinOtelSetup implements AutoCloseable {
          * @return setup with all OTel building blocks
          */
         public ZipkinOtelSetup register(ObservationRegistry registry) {
-            Sender sender = this.sender != null ? this.sender.get() : sender(this.zipkinUrl);
+            BytesMessageSender sender = this.sender != null ? this.sender.get() : sender(this.zipkinUrl);
             ZipkinSpanExporter zipkinSpanExporter = this.zipkinSpanExporter != null
                     ? this.zipkinSpanExporter.apply(sender) : zipkinSpanExporter(sender);
             ArrayListSpanProcessor arrayListSpanProcessor = new ArrayListSpanProcessor();
@@ -413,7 +413,7 @@ public final class ZipkinOtelSetup implements AutoCloseable {
             return new ZipkinOtelSetup(closingFunction, otelBuildingBlocks);
         }
 
-        private static Sender sender(String zipkinUrl) {
+        private static BytesMessageSender sender(String zipkinUrl) {
             return URLConnectionSender.newBuilder()
                 .connectTimeout(1000)
                 .readTimeout(1000)
@@ -422,7 +422,7 @@ public final class ZipkinOtelSetup implements AutoCloseable {
                 .build();
         }
 
-        private static ZipkinSpanExporter zipkinSpanExporter(Sender sender) {
+        private static ZipkinSpanExporter zipkinSpanExporter(BytesMessageSender sender) {
             return ZipkinSpanExporter.builder().setSender(sender).build();
         }
 


### PR DESCRIPTION
This updates to latest otel 0.35.0 which lets tests use latest zipkin-reporter 3.x. There are no changes to main code except some doc fuzz caused by running the gradle build.