### PR TITLE
Added a TestSpanReporter

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/CompositeSpanHandler.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/CompositeSpanHandler.java
@@ -15,16 +15,17 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
-import java.util.Collections;
-import java.util.List;
-
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.exporter.FinishedSpan;
 import io.micrometer.tracing.exporter.SpanExportingPredicate;
 import io.micrometer.tracing.exporter.SpanFilter;
 import io.micrometer.tracing.exporter.SpanReporter;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Wraps the {@link SpanHandler} with additional predicate, reporting and filtering logic.
@@ -46,8 +47,8 @@ public class CompositeSpanHandler extends SpanHandler {
      * @param reporters reporters that export spans
      * @param spanFilters filters that mutate spans before reporting them
      */
-    public CompositeSpanHandler(List<SpanExportingPredicate> predicates, List<SpanReporter> reporters,
-            List<SpanFilter> spanFilters) {
+    public CompositeSpanHandler(@Nullable List<SpanExportingPredicate> predicates,
+            @Nullable List<SpanReporter> reporters, @Nullable List<SpanFilter> spanFilters) {
         this.filters = predicates == null ? Collections.emptyList() : predicates;
         this.reporters = reporters == null ? Collections.emptyList() : reporters;
         this.spanFilters = spanFilters == null ? Collections.emptyList() : spanFilters;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/CompositeSpanHandlerTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/CompositeSpanHandlerTests.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.brave.bridge;
+
+import brave.handler.MutableSpan;
+import brave.handler.SpanHandler.Cause;
+import brave.internal.codec.HexCodec;
+import brave.propagation.TraceContext;
+import io.micrometer.tracing.exporter.TestSpanReporter;
+import org.assertj.core.api.BDDAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+class CompositeSpanHandlerTests {
+
+    @Test
+    void should_store_spans_through_test_span_reporter() {
+        TestSpanReporter testSpanReporter = new TestSpanReporter();
+        TraceContext traceContext = TraceContext.newBuilder().traceId(id()).spanId(id()).build();
+        MutableSpan mutableSpan = new MutableSpan(traceContext, null);
+        mutableSpan.name("bar");
+
+        boolean success = new CompositeSpanHandler(null, Collections.singletonList(testSpanReporter), null)
+            .end(traceContext, mutableSpan, Cause.FINISHED);
+
+        BDDAssertions.then(success).isTrue();
+        BDDAssertions.then(testSpanReporter.spans()).hasSize(1);
+        BDDAssertions.then(testSpanReporter.poll().getName()).isEqualTo("bar");
+    }
+
+    private static long id() {
+        return HexCodec.lowerHexToUnsignedLong("ff000000000000000000000000000041");
+    }
+
+}

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/CompositeSpanExporter.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/CompositeSpanExporter.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.tracing.otel.bridge;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.exporter.FinishedSpan;
 import io.micrometer.tracing.exporter.SpanExportingPredicate;
 import io.micrometer.tracing.exporter.SpanFilter;
@@ -53,9 +54,10 @@ public class CompositeSpanExporter implements io.opentelemetry.sdk.trace.export.
      * @param reporters reporters that export spans
      * @param spanFilters filters that mutate spans before reporting them
      */
-    public CompositeSpanExporter(Collection<io.opentelemetry.sdk.trace.export.SpanExporter> exporters,
-            List<SpanExportingPredicate> predicates, List<SpanReporter> reporters, List<SpanFilter> spanFilters) {
-        this.exporters = exporters;
+    public CompositeSpanExporter(@Nullable Collection<io.opentelemetry.sdk.trace.export.SpanExporter> exporters,
+            @Nullable List<SpanExportingPredicate> predicates, @Nullable List<SpanReporter> reporters,
+            @Nullable List<SpanFilter> spanFilters) {
+        this.exporters = exporters == null ? Collections.emptyList() : exporters;
         this.predicates = predicates == null ? Collections.emptyList() : predicates;
         this.reporters = reporters == null ? Collections.emptyList() : reporters;
         this.spanFilters = spanFilters == null ? Collections.emptyList() : spanFilters;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/CompositeSpanExporterTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/CompositeSpanExporterTests.java
@@ -18,6 +18,7 @@ package io.micrometer.tracing.otel.bridge;
 import io.micrometer.tracing.exporter.SpanExportingPredicate;
 import io.micrometer.tracing.exporter.SpanFilter;
 import io.micrometer.tracing.exporter.SpanReporter;
+import io.micrometer.tracing.exporter.TestSpanReporter;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
@@ -110,6 +111,20 @@ class CompositeSpanExporterTests {
 
         then(exporter).shouldHaveNoInteractions();
         BDDAssertions.then(resultCode.isSuccess()).isTrue();
+    }
+
+    @Test
+    void should_store_spans_through_test_span_reporter() {
+        TestSpanReporter testSpanReporter = new TestSpanReporter();
+        SpanData barSpan = new CustomSpanData("bar");
+
+        CompletableResultCode resultCode = new CompositeSpanExporter(null, null,
+                Collections.singletonList(testSpanReporter), null)
+            .export(Collections.singletonList(barSpan));
+
+        BDDAssertions.then(resultCode.isSuccess()).isTrue();
+        BDDAssertions.then(testSpanReporter.spans()).hasSize(1);
+        BDDAssertions.then(testSpanReporter.poll().getName()).isEqualTo("bar");
     }
 
     static class CustomSpanData implements SpanData {

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/exporter/TestSpanReporter.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/exporter/TestSpanReporter.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.exporter;
+
+import io.micrometer.common.lang.Nullable;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * {@link SpanReporter} with access to stored {@link FinishedSpan}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.3.0
+ */
+public class TestSpanReporter implements SpanReporter {
+
+    private final Queue<FinishedSpan> spans = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Polls stored spans for the latest entry.
+     * @return latest stored span
+     */
+    @Nullable
+    public FinishedSpan poll() {
+        return this.spans.poll();
+    }
+
+    /**
+     * Returns collected spans.
+     * @return collected spans
+     */
+    public Queue<FinishedSpan> spans() {
+        return new ConcurrentLinkedQueue<>(this.spans);
+    }
+
+    @Override
+    public void report(FinishedSpan span) {
+        this.spans.add(span);
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.spans.clear();
+    }
+
+}


### PR DESCRIPTION
with this change we're adding an implementation of the SpanReporter, a TestSpanReporter that can store FinishedSpans upon span reporting. That way we have 1 API to handle spans for tests regardless of used tracer.

fixes gh-463