### PR TITLE
Fix wrong baggage scope closing order in ObservationAwareBaggageThreadLocalAccessor

### DIFF
--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/java/io/micrometer/tracing/test/contextpropagation/AbstractObservationAwareSpanThreadLocalAccessorTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/src/test/java/io/micrometer/tracing/test/contextpropagation/AbstractObservationAwareSpanThreadLocalAccessorTests.java
@@ -378,20 +378,21 @@ abstract class AbstractObservationAwareSpanThreadLocalAccessorTests {
     }
 
     @Test
-    void observationAwareBaggageThreadLocalAccessorSetsAndClosesBaggageToPropagate() throws ReflectiveOperationException {
+    void observationAwareBaggageThreadLocalAccessorSetsAndClosesBaggageToPropagate()
+            throws ReflectiveOperationException {
         then(getTracer().currentTraceContext().context()).isNull();
 
-        Observation.createNotStarted("First span", observationRegistry).observeChecked(
-            () -> {
-                then(getTracer().currentTraceContext().context()).isNotNull();
+        Observation.createNotStarted("First span", observationRegistry).observeChecked(() -> {
+            then(getTracer().currentTraceContext().context()).isNotNull();
 
-                BaggageToPropagate baggageToPropagate = new BaggageToPropagate("tenant", "tenantValue", "tenant2", "tenant2Value");
-                observationAwareBaggageThreadLocalAccessor.setValue(baggageToPropagate);
-                Method closeCurrentScope = ObservationAwareBaggageThreadLocalAccessor.class.getDeclaredMethod("closeCurrentScope");
-                closeCurrentScope.setAccessible(true);
-                return closeCurrentScope.invoke(observationAwareBaggageThreadLocalAccessor);
-            }
-        );
+            BaggageToPropagate baggageToPropagate = new BaggageToPropagate("tenant", "tenantValue", "tenant2",
+                    "tenant2Value");
+            observationAwareBaggageThreadLocalAccessor.setValue(baggageToPropagate);
+            Method closeCurrentScope = ObservationAwareBaggageThreadLocalAccessor.class
+                .getDeclaredMethod("closeCurrentScope");
+            closeCurrentScope.setAccessible(true);
+            return closeCurrentScope.invoke(observationAwareBaggageThreadLocalAccessor);
+        });
 
         then(getTracer().currentTraceContext().context()).isNull();
     }

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/ObservationAwareBaggageThreadLocalAccessor.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/ObservationAwareBaggageThreadLocalAccessor.java
@@ -160,7 +160,6 @@ public class ObservationAwareBaggageThreadLocalAccessor implements ThreadLocalAc
         if (scope == null) {
             return scopeClosingBaggageAndScope(entry, baggage);
         }
-
         return scopeClosingBaggageAndScope(entry, baggage).andThen(scope);
     }
 

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/ObservationAwareBaggageThreadLocalAccessor.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/contextpropagation/ObservationAwareBaggageThreadLocalAccessor.java
@@ -160,7 +160,8 @@ public class ObservationAwareBaggageThreadLocalAccessor implements ThreadLocalAc
         if (scope == null) {
             return scopeClosingBaggageAndScope(entry, baggage);
         }
-        return scope.andThen(scopeClosingBaggageAndScope(entry, baggage));
+
+        return scopeClosingBaggageAndScope(entry, baggage).andThen(scope);
     }
 
     private static BaggageAndScope scopeClosingBaggageAndScope(Entry<String, String> entry, BaggageInScope baggage) {


### PR DESCRIPTION
This PR is related to #579 . It was kind of hard to reproduce the exact problem using a test but I managed to do so via reflection (I hope that it fine). The test just sets a baggageToPropagate directly using the accessor in the main thread and then immediately closes the scopes. If you do not fix the order of the closing scopes the OTelConfig test will fail and actually will affect trailing tests because the scopes are interfering with each other. Feel free to give suggestions on how to better test this :)