### PR TITLE
Implement setParent() for SimpleTracer, implement assertions for parentId

### DIFF
--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SpanAssert.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SpanAssert.java
@@ -905,7 +905,8 @@ public class SpanAssert<SELF extends SpanAssert<SELF>> extends AbstractAssert<SE
         }
 
         if (!parentSpanId.equals(this.actual.getParentId())) {
-            failWithMessage("Span should have parent span id equal to <%s> but has <%s>", parentSpanId, this.actual.getParentId());
+            failWithMessage("Span should have parent span id equal to <%s> but has <%s>", parentSpanId,
+                    this.actual.getParentId());
         }
         return (SELF) this;
     }

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SpanAssert.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SpanAssert.java
@@ -16,6 +16,7 @@
 package io.micrometer.tracing.test.simple;
 
 import io.micrometer.common.docs.KeyName;
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.tracing.Link;
 import io.micrometer.tracing.Span;
@@ -895,13 +896,19 @@ public class SpanAssert<SELF extends SpanAssert<SELF>> extends AbstractAssert<SE
      * @return {@code this} assertion object.
      * @throws AssertionError if the actual value is {@code null}.
      * @throws AssertionError if span has a parent span id not equal to the given one
-     * @since 1.0.4
+     * @since 1.3.0
      */
-    public SELF hasParentIdEqualTo(String parentSpanId) {
+    public SELF hasParentIdEqualTo(@Nullable String parentSpanId) {
         isNotNull();
 
-        if (parentSpanId == null && this.actual.getParentId() == null) {
-            return (SELF) this;
+        if (parentSpanId == null) {
+            if (this.actual.getParentId() == null) {
+                return (SELF) this;
+            }
+            else {
+                failWithMessage("Span should have parent span id equal to <null> but has <%s>",
+                        this.actual.getParentId());
+            }
         }
 
         if (!parentSpanId.equals(this.actual.getParentId())) {
@@ -923,14 +930,21 @@ public class SpanAssert<SELF extends SpanAssert<SELF>> extends AbstractAssert<SE
      * @return {@code this} assertion object.
      * @throws AssertionError if the actual value is {@code null}.
      * @throws AssertionError if span has a parent span id equal to the given one
-     * @since 1.0.4
+     * @since 1.3.0
      */
-    public SELF doesNotHaveParentIdEqualTo(String parentSpanId) {
+    public SELF doesNotHaveParentIdEqualTo(@Nullable String parentSpanId) {
         isNotNull();
-        if (this.actual.getParentId() == null && parentSpanId != null) {
-            return (SELF) this;
+
+        if (parentSpanId == null) {
+            if (this.actual.getParentId() != null) {
+                return (SELF) this;
+            }
+            else {
+                failWithMessage("Span should not have parent span id equal to <null>");
+            }
         }
-        if (this.actual.getParentId().equals(parentSpanId)) {
+
+        if (parentSpanId.equals(this.actual.getParentId())) {
             failWithMessage("Span should not have parent span id equal to <%s>", parentSpanId);
         }
         return (SELF) this;

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SpanAssert.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SpanAssert.java
@@ -884,6 +884,58 @@ public class SpanAssert<SELF extends SpanAssert<SELF>> extends AbstractAssert<SE
     }
 
     /**
+     * Verifies that this span has parent span id equal to the given value.
+     * <p>
+     * Examples: <pre><code class='java'> // assertions succeed
+     * assertThat(spanWithParentId456).hasParentIdEqualTo("456");
+     *
+     * // assertions fail
+     * assertThat(spanWithParentId123).hasSpanIdEqualTo("234");</code></pre>
+     * @param parentSpanId parent span id
+     * @return {@code this} assertion object.
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if span has a parent span id not equal to the given one
+     * @since 1.0.4
+     */
+    public SELF hasParentIdEqualTo(String parentSpanId) {
+        isNotNull();
+
+        if (parentSpanId == null && this.actual.getParentId() == null) {
+            return (SELF) this;
+        }
+
+        if (!parentSpanId.equals(this.actual.getParentId())) {
+            failWithMessage("Span should have parent span id equal to <%s> but has <%s>", parentSpanId, this.actual.getParentId());
+        }
+        return (SELF) this;
+    }
+
+    /**
+     * Verifies that this span doesn't have parent span id equal to the given value.
+     * <p>
+     * Examples: <pre><code class='java'> // assertions succeed
+     * assertThat(spanWithParentId123).hasSpanIdEqualTo("234");
+     *
+     * // assertions fail
+     * assertThat(spanWithId123).hasSpanIdEqualTo("123");</code></pre>
+     * @param parentSpanId parent span ID
+     * @return {@code this} assertion object.
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if span has a parent span id equal to the given one
+     * @since 1.0.4
+     */
+    public SELF doesNotHaveParentIdEqualTo(String parentSpanId) {
+        isNotNull();
+        if (this.actual.getParentId() == null && parentSpanId != null) {
+            return (SELF) this;
+        }
+        if (this.actual.getParentId().equals(parentSpanId)) {
+            failWithMessage("Span should not have parent span id equal to <%s>", parentSpanId);
+        }
+        return (SELF) this;
+    }
+
+    /**
      * Verifies that this span has trace id equal to the given value.
      * <p>
      * Examples: <pre><code class='java'> // assertions succeed

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SimpleSpanBuilderTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SimpleSpanBuilderTests.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import io.micrometer.tracing.Link;
 import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
 import org.junit.jupiter.api.Test;
 
 class SimpleSpanBuilderTests {
@@ -57,6 +58,25 @@ class SimpleSpanBuilderTests {
             .hasLink(new Link(context2, tags()))
             .assertThatThrowable()
             .isInstanceOf(Throwable.class);
+    }
+
+    @Test
+    void should_build_a_span_using_builder_with_parent() {
+        SimpleTracer simpleTracer = new SimpleTracer();
+        SimpleSpanBuilder builder = new SimpleSpanBuilder(simpleTracer);
+        SimpleTraceContextBuilder ctxBuilder = new SimpleTraceContextBuilder();
+        TraceContext parentCtx = ctxBuilder.spanId("spam").traceId("bar").sampled(true).build();
+
+        builder.name("foo")
+            .setParent(parentCtx)
+            .start()
+            .end();
+
+        TracerAssert.assertThat(simpleTracer)
+            .onlySpan()
+            .hasNameEqualTo("foo")
+            .hasTraceIdEqualTo("bar")
+            .hasParentIdEqualTo("spam");
     }
 
     private Map<String, Object> tags() {

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SimpleSpanBuilderTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SimpleSpanBuilderTests.java
@@ -67,10 +67,7 @@ class SimpleSpanBuilderTests {
         SimpleTraceContextBuilder ctxBuilder = new SimpleTraceContextBuilder();
         TraceContext parentCtx = ctxBuilder.spanId("spam").traceId("bar").sampled(true).build();
 
-        builder.name("foo")
-            .setParent(parentCtx)
-            .start()
-            .end();
+        builder.name("foo").setParent(parentCtx).start().end();
 
         TracerAssert.assertThat(simpleTracer)
             .onlySpan()

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SpanAssertTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SpanAssertTests.java
@@ -489,6 +489,40 @@ class SpanAssertTests {
     }
 
     @Test
+    void should_fail_when_parentId_is_not_equal() {
+        SimpleSpan span = new SimpleSpan();
+        span.context().setParentId("1");
+
+        thenThrownBy(() -> assertThat(span).hasParentIdEqualTo("2")).isInstanceOf(AssertionError.class);
+    }
+
+
+    @Test
+    void should_not_fail_when_parentId_is_equal() {
+        SimpleSpan span = new SimpleSpan();
+        span.context().setParentId("1");
+
+        thenNoException().isThrownBy(() -> assertThat(span).hasParentIdEqualTo("1"));
+    }
+
+    @Test
+    void should_not_fail_when_parentId_is_not_equal() {
+        SimpleSpan span = new SimpleSpan();
+        span.context().setSpanId("1");
+
+        thenNoException().isThrownBy(() -> assertThat(span).doesNotHaveSpanIdEqualTo("2"));
+    }
+
+    @Test
+    void should_fail_when_parentId_is_equal() {
+        SimpleSpan span = new SimpleSpan();
+        span.context().setParentId("1");
+
+        thenThrownBy(() -> assertThat(span).doesNotHaveParentIdEqualTo(span.getParentId()))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
     void should_not_fail_when_spanId_is_not_equal() {
         SimpleSpan span = new SimpleSpan();
         span.context().setSpanId("1");

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SpanAssertTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SpanAssertTests.java
@@ -496,7 +496,6 @@ class SpanAssertTests {
         thenThrownBy(() -> assertThat(span).hasParentIdEqualTo("2")).isInstanceOf(AssertionError.class);
     }
 
-
     @Test
     void should_not_fail_when_parentId_is_equal() {
         SimpleSpan span = new SimpleSpan();

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SpanAssertTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/simple/SpanAssertTests.java
@@ -493,14 +493,21 @@ class SpanAssertTests {
         SimpleSpan span = new SimpleSpan();
         span.context().setParentId("1");
 
-        thenThrownBy(() -> assertThat(span).hasParentIdEqualTo("2")).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(span).hasParentIdEqualTo("2")).isInstanceOf(AssertionError.class)
+            .hasNoCause()
+            .hasMessage("Span should have parent span id equal to <2> but has <1>");
+
+        thenThrownBy(() -> assertThat(span).hasParentIdEqualTo(null)).isInstanceOf(AssertionError.class)
+            .hasNoCause()
+            .hasMessage("Span should have parent span id equal to <null> but has <1>");
     }
 
     @Test
     void should_not_fail_when_parentId_is_equal() {
         SimpleSpan span = new SimpleSpan();
+        span.context().setParentId(null);
+        thenNoException().isThrownBy(() -> assertThat(span).hasParentIdEqualTo(null));
         span.context().setParentId("1");
-
         thenNoException().isThrownBy(() -> assertThat(span).hasParentIdEqualTo("1"));
     }
 
@@ -509,7 +516,10 @@ class SpanAssertTests {
         SimpleSpan span = new SimpleSpan();
         span.context().setSpanId("1");
 
-        thenNoException().isThrownBy(() -> assertThat(span).doesNotHaveSpanIdEqualTo("2"));
+        thenNoException().isThrownBy(() -> assertThat(span).doesNotHaveParentIdEqualTo("2"));
+        thenNoException().isThrownBy(() -> assertThat(span).doesNotHaveParentIdEqualTo(null));
+        span.context().setParentId(null);
+        thenNoException().isThrownBy(() -> assertThat(span).doesNotHaveParentIdEqualTo("1"));
     }
 
     @Test
@@ -518,7 +528,15 @@ class SpanAssertTests {
         span.context().setParentId("1");
 
         thenThrownBy(() -> assertThat(span).doesNotHaveParentIdEqualTo(span.getParentId()))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasNoCause()
+            .hasMessage("Span should not have parent span id equal to <1>");
+
+        span.context().setParentId(null);
+        thenThrownBy(() -> assertThat(span).doesNotHaveParentIdEqualTo(span.getParentId()))
+            .isInstanceOf(AssertionError.class)
+            .hasNoCause()
+            .hasMessage("Span should not have parent span id equal to <null>");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/micrometer-metrics/tracing/issues/675

I've also added assertions for parent ID since they didn't exist before, and it was useful for testing the change to SimpleTracer.