### PR TITLE
Added an option to have baggage through Observation API

### DIFF
--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -65,6 +65,21 @@ IMPORTANT: For Brave, remember to set up the `PropagationFactory` so that it con
 include::{include-java}/tracing/TracingApiTests.java[tags=baggage_brave_setup,indent=0]
 -----
 
+=== Baggage with Micrometer Observation API
+
+If you're using Micrometer Observation API, there's no notion of baggage. If you set up a `BaggageManager` to have the baggage fields configured, we will assume that when the Observation gets put in scope, whatever low and high cardinality keys are set on the Observation will be put in scope as baggage (assuming that their names match with the configuration on the `BaggageManager`). Below you can find example of such setup with OpenTelemetry `BaggageManager`.
+
+[source,java,subs=+attributes]
+-----
+include::{include-bridges-java}/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/BaggageTests.java[tags=baggageManager,indent=0]
+
+include::{include-bridges-java}/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/BaggageTests.java[tags=observationRegistrySetup,indent=0]
+
+include::{include-bridges-java}/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/BaggageTests.java[tags=observation,indent=0]
+
+include::{include-bridges-java}/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/BaggageTests.java[tags=observationScope,indent=0]
+-----
+
 == Aspect Oriented Programming
 
 Micrometer Tracing contains `@NewSpan`, `@ContinueSpan`, and `@SpanTag` annotations that frameworks can use to create or customize spans for either specific types of methods such as those serving web request endpoints or, more generally, to all methods.

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageManager.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageManager.java
@@ -36,6 +36,8 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
 
     private final List<String> remoteFields;
 
+    private final List<String> baggageFields;
+
     @Nullable
     private Tracer tracer;
 
@@ -46,10 +48,11 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
      */
     public BraveBaggageManager(List<String> tagFields, List<String> remoteFields) {
         this.tagFields = tagFields;
-        this.remoteFields = remoteFields(tagFields, remoteFields);
+        this.remoteFields = remoteFields;
+        this.baggageFields = baggageFields(tagFields, remoteFields);
     }
 
-    private static List<String> remoteFields(List<String> tagFields, List<String> remoteFields) {
+    private static List<String> baggageFields(List<String> tagFields, List<String> remoteFields) {
         Set<String> combined = new HashSet<>(tagFields);
         combined.addAll(remoteFields);
         return new ArrayList<>(combined);
@@ -62,6 +65,7 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
     public BraveBaggageManager() {
         this.tagFields = Collections.emptyList();
         this.remoteFields = Collections.emptyList();
+        this.baggageFields = Collections.emptyList();
     }
 
     /**
@@ -70,7 +74,8 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
      */
     public BraveBaggageManager(List<String> tagFields) {
         this.tagFields = tagFields;
-        this.remoteFields = new ArrayList<>(tagFields);
+        this.remoteFields = Collections.emptyList();
+        this.baggageFields = new ArrayList<>(tagFields);
     }
 
     @Override
@@ -155,8 +160,8 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
     }
 
     @Override
-    public List<String> getRemoteFields() {
-        return this.remoteFields;
+    public List<String> getBaggageFields() {
+        return this.baggageFields;
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageManager.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.*;
 
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -36,15 +37,25 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
 
     private final List<String> tagFields;
 
+    private final List<String> remoteFields;
+
     @Nullable
     private Tracer tracer;
 
     /**
      * Create an instance of {@link BraveBaggageManager}.
      * @param tagFields fields of baggage keys that should become tags on a span
+     * @param remoteFields fields of baggage keys that should be propagated over the wire
      */
-    public BraveBaggageManager(List<String> tagFields) {
+    public BraveBaggageManager(List<String> tagFields, List<String> remoteFields) {
         this.tagFields = tagFields;
+        this.remoteFields = remoteFields(tagFields, remoteFields);
+    }
+
+    private static List<String> remoteFields(List<String> tagFields, List<String> remoteFields) {
+        List<String> combined = new ArrayList<>(tagFields);
+        combined.addAll(remoteFields);
+        return combined;
     }
 
     /**
@@ -53,6 +64,16 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
      */
     public BraveBaggageManager() {
         this.tagFields = Collections.emptyList();
+        this.remoteFields = Collections.emptyList();
+    }
+
+    /**
+     * Create an instance of {@link BraveBaggageManager}.
+     * @param tagFields fields of baggage keys that should become tags on a span
+     */
+    public BraveBaggageManager(List<String> tagFields) {
+        this.tagFields = tagFields;
+        this.remoteFields = new ArrayList<>(tagFields);
     }
 
     @Override
@@ -134,6 +155,11 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
 
     void setTracer(Tracer tracer) {
         this.tracer = tracer;
+    }
+
+    @Override
+    public List<String> getRemoteFields() {
+        return this.remoteFields;
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageManager.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageManager.java
@@ -22,10 +22,7 @@ import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.*;
 
 import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Brave implementation of a {@link BaggageManager}.
@@ -53,9 +50,9 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
     }
 
     private static List<String> remoteFields(List<String> tagFields, List<String> remoteFields) {
-        List<String> combined = new ArrayList<>(tagFields);
+        Set<String> combined = new HashSet<>(tagFields);
         combined.addAll(remoteFields);
-        return combined;
+        return new ArrayList<>(combined);
     }
 
     /**

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTracer.java
@@ -158,8 +158,8 @@ public class BraveTracer implements Tracer {
     }
 
     @Override
-    public List<String> getRemoteFields() {
-        return this.braveBaggageManager.getRemoteFields();
+    public List<String> getBaggageFields() {
+        return this.braveBaggageManager.getBaggageFields();
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTracer.java
@@ -18,6 +18,7 @@ package io.micrometer.tracing.brave.bridge;
 import brave.propagation.TraceContextOrSamplingFlags;
 import io.micrometer.tracing.*;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -154,6 +155,11 @@ public class BraveTracer implements Tracer {
     @Override
     public CurrentTraceContext currentTraceContext() {
         return this.currentTraceContext;
+    }
+
+    @Override
+    public List<String> getRemoteFields() {
+        return this.braveBaggageManager.getRemoteFields();
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BaggageTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BaggageTests.java
@@ -278,10 +278,14 @@ class BaggageTests {
         Observation observation = Observation.start("foo", observationRegistry)
             .lowCardinalityKeyValue(KEY_1, TAG_VALUE)
             .highCardinalityKeyValue(OBSERVATION_BAGGAGE_KEY, OBSERVATION_BAGGAGE_VALUE);
+        then(tracer.getBaggage(KEY_1).get()).isNull();
+        then(tracer.getBaggage(OBSERVATION_BAGGAGE_KEY).get()).isNull();
+
         try (Scope scope = observation.openScope()) {
             then(tracer.getBaggage(KEY_1).get()).isEqualTo(TAG_VALUE);
             then(tracer.getBaggage(OBSERVATION_BAGGAGE_KEY).get()).isEqualTo(OBSERVATION_BAGGAGE_VALUE);
         }
+
         then(tracer.currentSpan()).isNull();
         then(tracer.getBaggage(KEY_1).get()).isNull();
         then(tracer.getBaggage(OBSERVATION_BAGGAGE_KEY).get()).isNull();

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BaggageTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BaggageTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,13 +27,17 @@ import brave.test.TestSpanHandler;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.context.ContextRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Scope;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import io.micrometer.tracing.*;
 import io.micrometer.tracing.contextpropagation.ObservationAwareSpanThreadLocalAccessor;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Hooks;
@@ -42,6 +46,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,6 +66,10 @@ class BaggageTests {
 
     public static final String TAG_VALUE = "tagValue";
 
+    public static final String OBSERVATION_BAGGAGE_KEY = "observationKey";
+
+    public static final String OBSERVATION_BAGGAGE_VALUE = "observationValue";
+
     TestSpanHandler spanHandler = new TestSpanHandler();
 
     StrictCurrentTraceContext braveCurrentTraceContext = StrictCurrentTraceContext.create();
@@ -73,6 +82,7 @@ class BaggageTests {
         .traceId128Bit(true)
         .propagationFactory(BaggagePropagation.newFactoryBuilder(B3Propagation.FACTORY)
             .add(BaggagePropagationConfig.SingleBaggageField.remote(BaggageField.create(KEY_1)))
+            .add(BaggagePropagationConfig.SingleBaggageField.remote(BaggageField.create(OBSERVATION_BAGGAGE_KEY)))
             .add(BaggagePropagationConfig.SingleBaggageField.local(BaggageField.create(TAG_KEY)))
             .build())
         .sampler(Sampler.ALWAYS_SAMPLE)
@@ -84,9 +94,14 @@ class BaggageTests {
     BravePropagator propagator = new BravePropagator(tracing);
 
     Tracer tracer = new BraveTracer(this.braveTracer, this.bridgeContext,
-            new BraveBaggageManager(Collections.singletonList(TAG_KEY)));
+            new BraveBaggageManager(Collections.singletonList(TAG_KEY), Arrays.asList(KEY_1, OBSERVATION_BAGGAGE_KEY)));
 
     ObservationRegistry observationRegistry = ObservationThreadLocalAccessor.getInstance().getObservationRegistry();
+
+    @BeforeEach
+    void setupHandler() {
+        observationRegistry.observationConfig().observationHandler(new DefaultTracingObservationHandler(tracer));
+    }
 
     @AfterEach
     void cleanup() {
@@ -256,6 +271,26 @@ class BaggageTests {
         then(spanHandler.spans()).hasSize(1);
         MutableSpan mutableSpan = spanHandler.spans().get(0);
         then(mutableSpan.tags().get(TAG_KEY)).isEqualTo(TAG_VALUE);
+    }
+
+    @Test
+    void baggageWithObservationApiWithRemoteFields() {
+        Observation observation = Observation.start("foo", observationRegistry)
+            .lowCardinalityKeyValue(KEY_1, TAG_VALUE)
+            .highCardinalityKeyValue(OBSERVATION_BAGGAGE_KEY, OBSERVATION_BAGGAGE_VALUE);
+        try (Scope scope = observation.openScope()) {
+            then(tracer.getBaggage(KEY_1).get()).isEqualTo(TAG_VALUE);
+            then(tracer.getBaggage(OBSERVATION_BAGGAGE_KEY).get()).isEqualTo(OBSERVATION_BAGGAGE_VALUE);
+        }
+        then(tracer.currentSpan()).isNull();
+        then(tracer.getBaggage(KEY_1).get()).isNull();
+        then(tracer.getBaggage(OBSERVATION_BAGGAGE_KEY).get()).isNull();
+        observation.stop();
+
+        then(spanHandler.spans()).hasSize(1);
+        MutableSpan mutableSpan = spanHandler.spans().get(0);
+        then(mutableSpan.tags().get(KEY_1)).isEqualTo(TAG_VALUE);
+        then(mutableSpan.tags().get(OBSERVATION_BAGGAGE_KEY)).isEqualTo(OBSERVATION_BAGGAGE_VALUE);
     }
 
     @Test

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageManager.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageManager.java
@@ -62,8 +62,14 @@ public class OtelBaggageManager implements BaggageManager {
     public OtelBaggageManager(CurrentTraceContext currentTraceContext, List<String> remoteFields,
             List<String> tagFields) {
         this.currentTraceContext = currentTraceContext;
-        this.remoteFields = remoteFields;
+        this.remoteFields = remoteFields(tagFields, remoteFields);
         this.tagFields = tagFields;
+    }
+
+    private static List<String> remoteFields(List<String> tagFields, List<String> remoteFields) {
+        List<String> combined = new ArrayList<>(tagFields);
+        combined.addAll(remoteFields);
+        return combined;
     }
 
     @Override

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageManager.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageManager.java
@@ -67,9 +67,9 @@ public class OtelBaggageManager implements BaggageManager {
     }
 
     private static List<String> remoteFields(List<String> tagFields, List<String> remoteFields) {
-        List<String> combined = new ArrayList<>(tagFields);
+        Set<String> combined = new HashSet<>(tagFields);
         combined.addAll(remoteFields);
-        return combined;
+        return new ArrayList<>(combined);
     }
 
     @Override

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageManager.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageManager.java
@@ -15,18 +15,6 @@
  */
 package io.micrometer.tracing.otel.bridge;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.BiConsumer;
-
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.BaggageInScope;
 import io.micrometer.tracing.BaggageManager;
@@ -37,6 +25,9 @@ import io.opentelemetry.api.baggage.BaggageBuilder;
 import io.opentelemetry.api.baggage.BaggageEntry;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.context.Context;
+
+import java.util.*;
+import java.util.function.BiConsumer;
 
 import static java.util.Collections.unmodifiableCollection;
 import static java.util.Collections.unmodifiableMap;
@@ -211,6 +202,11 @@ public class OtelBaggageManager implements BaggageManager {
             propagation = PROPAGATION_UNLIMITED;
         }
         return propagation;
+    }
+
+    @Override
+    public List<String> getRemoteFields() {
+        return this.remoteFields;
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageManager.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageManager.java
@@ -51,6 +51,8 @@ public class OtelBaggageManager implements BaggageManager {
 
     private final List<String> remoteFields;
 
+    private final List<String> baggageFields;
+
     private final List<String> tagFields;
 
     /**
@@ -62,11 +64,12 @@ public class OtelBaggageManager implements BaggageManager {
     public OtelBaggageManager(CurrentTraceContext currentTraceContext, List<String> remoteFields,
             List<String> tagFields) {
         this.currentTraceContext = currentTraceContext;
-        this.remoteFields = remoteFields(tagFields, remoteFields);
+        this.remoteFields = remoteFields;
         this.tagFields = tagFields;
+        this.baggageFields = baggageFields(tagFields, remoteFields);
     }
 
-    private static List<String> remoteFields(List<String> tagFields, List<String> remoteFields) {
+    private static List<String> baggageFields(List<String> tagFields, List<String> remoteFields) {
         Set<String> combined = new HashSet<>(tagFields);
         combined.addAll(remoteFields);
         return new ArrayList<>(combined);
@@ -211,7 +214,7 @@ public class OtelBaggageManager implements BaggageManager {
     }
 
     @Override
-    public List<String> getRemoteFields() {
+    public List<String> getBaggageFields() {
         return this.remoteFields;
     }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import io.micrometer.tracing.*;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -194,6 +195,11 @@ public class OtelTracer implements Tracer {
     @Override
     public BaggageInScope createBaggageInScope(TraceContext traceContext, String name, String value) {
         return this.otelBaggageManager.createBaggageInScope(traceContext, name, value);
+    }
+
+    @Override
+    public List<String> getRemoteFields() {
+        return this.otelBaggageManager.getRemoteFields();
     }
 
     /**

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
@@ -198,8 +198,8 @@ public class OtelTracer implements Tracer {
     }
 
     @Override
-    public List<String> getRemoteFields() {
-        return this.otelBaggageManager.getRemoteFields();
+    public List<String> getBaggageFields() {
+        return this.otelBaggageManager.getBaggageFields();
     }
 
     /**

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/BaggageTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/BaggageTests.java
@@ -1,23 +1,23 @@
 /**
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  * <p>
  * https://www.apache.org/licenses/LICENSE-2.0
  * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package io.micrometer.tracing.otel.bridge;
 
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.context.ContextRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Scope;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import io.micrometer.tracing.BaggageInScope;
@@ -25,6 +25,7 @@ import io.micrometer.tracing.ScopedSpan;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.contextpropagation.ObservationAwareSpanThreadLocalAccessor;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
 import io.micrometer.tracing.otel.propagation.BaggageTextMapPropagator;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.common.AttributeKey;
@@ -38,6 +39,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Hooks;
@@ -46,6 +48,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -69,6 +72,10 @@ class BaggageTests {
 
     public static final String TAG_VALUE = "tagValue";
 
+    public static final String OBSERVATION_BAGGAGE_KEY = "observationKey";
+
+    public static final String OBSERVATION_BAGGAGE_VALUE = "observationValue";
+
     ArrayListSpanProcessor spanExporter = new ArrayListSpanProcessor();
 
     SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
@@ -86,11 +93,11 @@ class BaggageTests {
     OtelCurrentTraceContext otelCurrentTraceContext = new OtelCurrentTraceContext();
 
     OtelBaggageManager otelBaggageManager = new OtelBaggageManager(otelCurrentTraceContext,
-            Collections.singletonList(KEY_1), Collections.singletonList(TAG_KEY));
+            Arrays.asList(KEY_1, OBSERVATION_BAGGAGE_KEY), Collections.singletonList(TAG_KEY));
 
     ContextPropagators contextPropagators = ContextPropagators
         .create(TextMapPropagator.composite(W3CBaggagePropagator.getInstance(), W3CTraceContextPropagator.getInstance(),
-                new BaggageTextMapPropagator(Collections.singletonList(KEY_1), otelBaggageManager)));
+                new BaggageTextMapPropagator(Arrays.asList(KEY_1, OBSERVATION_BAGGAGE_KEY), otelBaggageManager)));
 
     OtelPropagator propagator = new OtelPropagator(contextPropagators, otelTracer);
 
@@ -98,6 +105,11 @@ class BaggageTests {
     }, otelBaggageManager);
 
     ObservationRegistry observationRegistry = ObservationThreadLocalAccessor.getInstance().getObservationRegistry();
+
+    @BeforeEach
+    void setupHandler() {
+        observationRegistry.observationConfig().observationHandler(new DefaultTracingObservationHandler(tracer));
+    }
 
     @Test
     void canSetAndGetBaggage() {
@@ -236,6 +248,27 @@ class BaggageTests {
         then(spanExporter.spans()).hasSize(1);
         SpanData spanData = spanExporter.spans().poll();
         then(spanData.getAttributes().get(AttributeKey.stringKey(TAG_KEY))).isEqualTo(TAG_VALUE);
+    }
+
+    @Test
+    void baggageWithObservationApiWithRemoteFields() {
+        Observation observation = Observation.start("foo", observationRegistry)
+            .lowCardinalityKeyValue(KEY_1, TAG_VALUE)
+            .highCardinalityKeyValue(OBSERVATION_BAGGAGE_KEY, OBSERVATION_BAGGAGE_VALUE);
+        try (Scope scope = observation.openScope()) {
+            then(tracer.getBaggage(KEY_1).get()).isEqualTo(TAG_VALUE);
+            then(tracer.getBaggage(OBSERVATION_BAGGAGE_KEY).get()).isEqualTo(OBSERVATION_BAGGAGE_VALUE);
+        }
+        then(tracer.currentSpan()).isNull();
+        then(tracer.getBaggage(KEY_1).get()).isNull();
+        then(tracer.getBaggage(OBSERVATION_BAGGAGE_KEY).get()).isNull();
+        observation.stop();
+
+        then(spanExporter.spans()).hasSize(1);
+        SpanData spanData = spanExporter.spans().poll();
+        then(spanData.getAttributes().get(AttributeKey.stringKey(KEY_1))).isEqualTo(TAG_VALUE);
+        then(spanData.getAttributes().get(AttributeKey.stringKey(OBSERVATION_BAGGAGE_KEY)))
+            .isEqualTo(OBSERVATION_BAGGAGE_VALUE);
     }
 
     @Test

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java
@@ -152,7 +152,7 @@ public class SimpleBaggageManager implements BaggageManager {
     }
 
     @Override
-    public List<String> getRemoteFields() {
+    public List<String> getBaggageFields() {
         return this.remoteFields;
     }
 

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,10 +19,7 @@ import io.micrometer.tracing.BaggageInScope;
 import io.micrometer.tracing.BaggageManager;
 import io.micrometer.tracing.TraceContext;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -39,12 +36,25 @@ public class SimpleBaggageManager implements BaggageManager {
 
     private final SimpleTracer simpleTracer;
 
+    private final List<String> remoteFields;
+
     /**
      * Creates a new instance of {@link SimpleBaggageManager}.
      * @param simpleTracer simple tracer
      */
     public SimpleBaggageManager(SimpleTracer simpleTracer) {
         this.simpleTracer = simpleTracer;
+        this.remoteFields = Collections.emptyList();
+    }
+
+    /**
+     * Creates a new instance of {@link SimpleBaggageManager}.
+     * @param simpleTracer simple tracer
+     * @param remoteFields fields of baggage keys that should be propagated over the wire
+     */
+    public SimpleBaggageManager(SimpleTracer simpleTracer, List<String> remoteFields) {
+        this.simpleTracer = simpleTracer;
+        this.remoteFields = remoteFields;
     }
 
     @Override
@@ -134,6 +144,16 @@ public class SimpleBaggageManager implements BaggageManager {
     @Override
     public BaggageInScope createBaggageInScope(TraceContext traceContext, String name, String value) {
         return createSimpleBaggage(name).makeCurrent(traceContext, value);
+    }
+
+    @Override
+    public Map<String, String> getAllBaggage(TraceContext traceContext) {
+        return getAllBaggageForCtx(traceContext);
+    }
+
+    @Override
+    public List<String> getRemoteFields() {
+        return this.remoteFields;
     }
 
 }

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleTracer.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleTracer.java
@@ -185,8 +185,8 @@ public class SimpleTracer implements Tracer {
     }
 
     @Override
-    public List<String> getRemoteFields() {
-        return this.simpleBaggageManager.getRemoteFields();
+    public List<String> getBaggageFields() {
+        return this.simpleBaggageManager.getBaggageFields();
     }
 
     /**

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleTracer.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleTracer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ import io.micrometer.tracing.*;
 
 import java.util.Collections;
 import java.util.Deque;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -181,6 +182,11 @@ public class SimpleTracer implements Tracer {
     @Override
     public BaggageInScope createBaggageInScope(TraceContext traceContext, String name, String value) {
         return this.simpleBaggageManager.createBaggageInScope(traceContext, name, value);
+    }
+
+    @Override
+    public List<String> getRemoteFields() {
+        return this.simpleBaggageManager.getRemoteFields();
     }
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/BaggageManager.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/BaggageManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.micrometer.tracing;
 import io.micrometer.common.lang.Nullable;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -143,6 +144,15 @@ public interface BaggageManager {
      */
     default BaggageInScope createBaggageInScope(TraceContext traceContext, String name, String value) {
         return createBaggage(name).makeCurrent(traceContext, value);
+    }
+
+    /**
+     * Returns field names that should be propagated over the wire.
+     * @return remote fields
+     * @since 1.3.0
+     */
+    default List<String> getRemoteFields() {
+        return Collections.emptyList();
     }
 
 }

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/BaggageManager.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/BaggageManager.java
@@ -147,11 +147,11 @@ public interface BaggageManager {
     }
 
     /**
-     * Returns field names that should be propagated over the wire.
-     * @return remote fields
+     * Returns all names of baggage fields.
+     * @return baggage fields
      * @since 1.3.0
      */
-    default List<String> getRemoteFields() {
+    default List<String> getBaggageFields() {
         return Collections.emptyList();
     }
 

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
@@ -78,7 +78,7 @@ class RevertingScope implements CurrentTraceContext.Scope {
         if (context == null) {
             return revertingScope;
         }
-        List<KeyValue> baggageKeyValues = matchingBaggageKeyValues(tracer, context);
+        Set<KeyValue> baggageKeyValues = matchingBaggageKeyValues(tracer, context);
         if (baggageKeyValues.isEmpty()) {
             return revertingScope;
         }
@@ -92,7 +92,7 @@ class RevertingScope implements CurrentTraceContext.Scope {
     }
 
     private static ArrayDeque<BaggageInScope> startBaggageScopes(Tracer tracer, TraceContext newContext,
-            List<KeyValue> baggageKeyValues) {
+            Set<KeyValue> baggageKeyValues) {
         ArrayDeque<BaggageInScope> scopes = new ArrayDeque<>();
         for (KeyValue keyValue : baggageKeyValues) {
             if (newContext != null) {
@@ -105,12 +105,12 @@ class RevertingScope implements CurrentTraceContext.Scope {
         return scopes;
     }
 
-    private static List<KeyValue> matchingBaggageKeyValues(Tracer tracer, ContextView context) {
-        List<String> lowerCaseRemoteFields = new ArrayList<>();
+    private static Set<KeyValue> matchingBaggageKeyValues(Tracer tracer, ContextView context) {
+        Set<String> lowerCaseRemoteFields = new HashSet<>();
         for (String remoteField : tracer.getRemoteFields()) {
             lowerCaseRemoteFields.add(remoteField.toLowerCase());
         }
-        List<KeyValue> baggageKeyValues = new ArrayList<>();
+        Set<KeyValue> baggageKeyValues = new HashSet<>();
         for (KeyValue keyValue : context.getAllKeyValues()) {
             if (lowerCaseRemoteFields.contains(keyValue.getKey().toLowerCase())) {
                 baggageKeyValues.add(keyValue);

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
@@ -78,7 +78,7 @@ class RevertingScope implements CurrentTraceContext.Scope {
         if (context == null) {
             return revertingScope;
         }
-        Set<KeyValue> baggageKeyValues = matchingBaggageKeyValues(tracer, context);
+        Collection<KeyValue> baggageKeyValues = matchingBaggageKeyValues(tracer, context);
         if (baggageKeyValues.isEmpty()) {
             return revertingScope;
         }
@@ -92,7 +92,7 @@ class RevertingScope implements CurrentTraceContext.Scope {
     }
 
     private static ArrayDeque<BaggageInScope> startBaggageScopes(Tracer tracer, TraceContext newContext,
-            Set<KeyValue> baggageKeyValues) {
+            Collection<KeyValue> baggageKeyValues) {
         ArrayDeque<BaggageInScope> scopes = new ArrayDeque<>();
         for (KeyValue keyValue : baggageKeyValues) {
             if (newContext != null) {
@@ -105,12 +105,12 @@ class RevertingScope implements CurrentTraceContext.Scope {
         return scopes;
     }
 
-    private static Set<KeyValue> matchingBaggageKeyValues(Tracer tracer, ContextView context) {
+    private static Collection<KeyValue> matchingBaggageKeyValues(Tracer tracer, ContextView context) {
         Set<String> lowerCaseRemoteFields = new HashSet<>();
         for (String remoteField : tracer.getBaggageFields()) {
             lowerCaseRemoteFields.add(remoteField.toLowerCase());
         }
-        Set<KeyValue> baggageKeyValues = new HashSet<>();
+        Collection<KeyValue> baggageKeyValues = new ArrayList<>();
         for (KeyValue keyValue : context.getAllKeyValues()) {
             if (lowerCaseRemoteFields.contains(keyValue.getKey().toLowerCase())) {
                 baggageKeyValues.add(keyValue);

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
@@ -107,7 +107,7 @@ class RevertingScope implements CurrentTraceContext.Scope {
 
     private static Set<KeyValue> matchingBaggageKeyValues(Tracer tracer, ContextView context) {
         Set<String> lowerCaseRemoteFields = new HashSet<>();
-        for (String remoteField : tracer.getRemoteFields()) {
+        for (String remoteField : tracer.getBaggageFields()) {
             lowerCaseRemoteFields.add(remoteField.toLowerCase());
         }
         Set<KeyValue> baggageKeyValues = new HashSet<>();


### PR DESCRIPTION
whenever a key-value matches a preconfigured baggage config and an Observation started a scope then automatically baggages will also be started

fixes gh-455

TODO: 

- [x] docs
- [ ] boot autoconfig to set up baggage on baggagemanagers

related https://github.com/micrometer-metrics/tracing/issues/455
