### PR TITLE
Assumes that INVALID parent span id is actually null in TraceContext

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTraceContext.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTraceContext.java
@@ -15,15 +15,15 @@
  */
 package io.micrometer.tracing.otel.bridge;
 
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
-
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.TraceContext;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * OpenTelemetry implementation of a {@link TraceContext}.
@@ -116,7 +116,11 @@ public class OtelTraceContext implements TraceContext {
                 : this.span;
         if (spanContextSpanOrSpan instanceof ReadableSpan) {
             ReadableSpan readableSpan = (ReadableSpan) spanContextSpanOrSpan;
-            return readableSpan.toSpanData().getParentSpanId();
+            String parentSpanId = readableSpan.toSpanData().getParentSpanId();
+            if (Objects.equals(Span.getInvalid().getSpanContext().getSpanId(), parentSpanId)) {
+                return null;
+            }
+            return parentSpanId;
         }
         return null;
     }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelTraceContextTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelTraceContextTests.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.micrometer.tracing.otel.bridge;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.OpenTelemetrySdkBuilder;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class OtelTraceContextTests {
+
+    SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+        .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())
+        .build();
+
+    OpenTelemetrySdkBuilder openTelemetrySdkBuilder = OpenTelemetrySdk.builder().setTracerProvider(sdkTracerProvider);
+
+    @Test
+    void should_return_null_when_parent_invalid() {
+
+        try (OpenTelemetrySdk openTelemetrySdk = openTelemetrySdkBuilder.build()) {
+            Tracer otelTracer = tracer(openTelemetrySdk);
+            Span span = otelTracer.spanBuilder("foo").startSpan();
+
+            OtelTraceContext otelTraceContext = new OtelTraceContext(span);
+
+            then(otelTraceContext.parentId()).isNull();
+        }
+
+    }
+
+    @Test
+    void should_return_parentid_when_parent_valid() {
+        try (OpenTelemetrySdk openTelemetrySdk = openTelemetrySdkBuilder.build()) {
+            Tracer otelTracer = tracer(openTelemetrySdk);
+            Span parentSpan = otelTracer.spanBuilder("parent").startSpan();
+            Span span = otelTracer.spanBuilder("foo")
+                .setParent(parentSpan.storeInContext(Context.current()))
+                .startSpan();
+
+            OtelTraceContext otelTraceContext = new OtelTraceContext(span);
+
+            then(otelTraceContext.parentId()).isEqualTo(parentSpan.getSpanContext().getSpanId());
+        }
+
+    }
+
+    private static Tracer tracer(OpenTelemetrySdk openTelemetrySdk) {
+        return openTelemetrySdk.getTracer("io.micrometer.micrometer-tracing");
+    }
+
+}


### PR DESCRIPTION
- without this change we're returning an INVALID parent span even though we define in the javadocs of TraceContext that we would return null
- with this change we're verifying whether the INVALID parent is set in which case we're returning null

fixes gh-687