### PR TITLE
Honors parent trace context even if there was no span

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTraceContext.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTraceContext.java
@@ -15,15 +15,15 @@
  */
 package io.micrometer.tracing.otel.bridge;
 
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
-
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.TraceContext;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * OpenTelemetry implementation of a {@link TraceContext}.
@@ -86,6 +86,9 @@ public class OtelTraceContext implements TraceContext {
             Span span = ((OtelTraceContext) context).span;
             if (span != null) {
                 return span.storeInContext(Context.current());
+            }
+            else {
+                return Context.current().with(Span.wrap(((OtelTraceContext) context).delegate));
             }
         }
         return Context.current();


### PR DESCRIPTION
- without this change, for OTel, we always look at spans when talking about setting a parent on a span. However it is completely valid to pass just trace context data (span id, trace id, sampling flag etc.)
- with this change, for OTel, we honor that setting and will look at both span and span trace context

fixes gh-698