### PR TITLE
Add `@Nullable` annotations

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageInScope.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageInScope.java
@@ -66,11 +66,13 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
     }
 
     @Override
+    @Nullable
     public String get() {
         return this.traceContext != null ? this.delegate.getValue(traceContext) : this.delegate.getValue();
     }
 
     @Override
+    @Nullable
     public String get(TraceContext traceContext) {
         return this.delegate.getValue(BraveTraceContext.toBrave(traceContext));
     }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageManager.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageManager.java
@@ -84,7 +84,7 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
     }
 
     @Override
-    public Map<String, String> getAllBaggage(TraceContext traceContext) {
+    public Map<String, String> getAllBaggage(@Nullable TraceContext traceContext) {
         if (traceContext == null) {
             return getAllBaggage();
         }
@@ -97,6 +97,7 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
     }
 
     @Override
+    @Nullable
     public Baggage getBaggage(TraceContext traceContext, String name) {
         BaggageField baggageField = BaggageField.getByName(BraveTraceContext.toBrave(traceContext), name);
         if (baggageField == null) {
@@ -125,6 +126,7 @@ public class BraveBaggageManager implements Closeable, BaggageManager {
     }
 
     // Taken from BraveField
+    @Nullable
     private Span currentSpan() {
         if (tracer != null) {
             io.micrometer.tracing.Span span = tracer.currentSpan();

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveCurrentTraceContext.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveCurrentTraceContext.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.CurrentTraceContext;
 import io.micrometer.tracing.TraceContext;
 
@@ -59,6 +60,7 @@ public class BraveCurrentTraceContext implements CurrentTraceContext {
     }
 
     @Override
+    @Nullable
     public TraceContext context() {
         brave.propagation.TraceContext context = this.delegate.get();
         if (context == null) {
@@ -68,13 +70,13 @@ public class BraveCurrentTraceContext implements CurrentTraceContext {
     }
 
     @Override
-    public Scope newScope(TraceContext context) {
+    public Scope newScope(@Nullable TraceContext context) {
         return new BraveScope(
                 this.delegate.newScope(io.micrometer.tracing.brave.bridge.BraveTraceContext.toBrave(context)));
     }
 
     @Override
-    public Scope maybeScope(TraceContext context) {
+    public Scope maybeScope(@Nullable TraceContext context) {
         return new BraveScope(
                 this.delegate.maybeScope(io.micrometer.tracing.brave.bridge.BraveTraceContext.toBrave(context)));
     }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveFinishedSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveFinishedSpan.java
@@ -16,6 +16,7 @@
 package io.micrometer.tracing.brave.bridge;
 
 import brave.handler.MutableSpan;
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.Link;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
@@ -154,6 +155,7 @@ public class BraveFinishedSpan implements FinishedSpan {
     }
 
     @Override
+    @Nullable
     public Throwable getError() {
         return this.mutableSpan.error();
     }
@@ -173,6 +175,7 @@ public class BraveFinishedSpan implements FinishedSpan {
     }
 
     @Override
+    @Nullable
     public String getRemoteServiceName() {
         return this.mutableSpan.remoteServiceName();
     }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BravePropagator.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BravePropagator.java
@@ -19,6 +19,7 @@ import brave.Tracing;
 import brave.baggage.BaggageField;
 import brave.internal.baggage.BaggageFields;
 import brave.propagation.TraceContextOrSamplingFlags;
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.propagation.Propagator;
@@ -49,7 +50,7 @@ public class BravePropagator implements Propagator {
     }
 
     @Override
-    public <C> void inject(TraceContext traceContext, C carrier, Setter<C> setter) {
+    public <C> void inject(TraceContext traceContext, @Nullable C carrier, Setter<C> setter) {
         this.tracing.propagation().injector(setter::set).inject(BraveTraceContext.toBrave(traceContext), carrier);
     }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveSpan.java
@@ -18,6 +18,7 @@ package io.micrometer.tracing.brave.bridge;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
 
@@ -44,7 +45,8 @@ public class BraveSpan implements Span {
      * @param span Tracing version
      * @return Brave's version
      */
-    public static brave.Span toBrave(Span span) {
+    @Nullable
+    public static brave.Span toBrave(@Nullable Span span) {
         BraveSpan braveSpan = (BraveSpan) span;
         if (braveSpan == null) {
             return null;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTraceContext.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTraceContext.java
@@ -43,7 +43,8 @@ public class BraveTraceContext implements TraceContext {
      * @param traceContext Tracing version
      * @return Brave version
      */
-    public static brave.propagation.TraceContext toBrave(TraceContext traceContext) {
+    @Nullable
+    public static brave.propagation.TraceContext toBrave(@Nullable TraceContext traceContext) {
         if (traceContext == null) {
             return null;
         }
@@ -76,6 +77,7 @@ public class BraveTraceContext implements TraceContext {
     }
 
     @Override
+    @Nullable
     public Boolean sampled() {
         return this.traceContext.sampled();
     }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveTracer.java
@@ -16,6 +16,7 @@
 package io.micrometer.tracing.brave.bridge;
 
 import brave.propagation.TraceContextOrSamplingFlags;
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.*;
 
 import java.util.List;
@@ -60,7 +61,8 @@ public class BraveTracer implements Tracer {
     }
 
     @Override
-    public Span nextSpan(Span parent) {
+    @Nullable
+    public Span nextSpan(@Nullable Span parent) {
         if (parent == null) {
             return nextSpan();
         }
@@ -72,7 +74,7 @@ public class BraveTracer implements Tracer {
     }
 
     @Override
-    public SpanInScope withSpan(Span span) {
+    public SpanInScope withSpan(@Nullable Span span) {
         return new BraveSpanInScope(tracer.withSpanInScope(span == null ? null : ((BraveSpan) span).delegate));
     }
 
@@ -82,6 +84,7 @@ public class BraveTracer implements Tracer {
     }
 
     @Override
+    @Nullable
     public Span currentSpan() {
         brave.Span currentSpan = this.tracer.currentSpan();
         if (currentSpan == null) {
@@ -111,7 +114,7 @@ public class BraveTracer implements Tracer {
     }
 
     @Override
-    public Map<String, String> getAllBaggage(TraceContext traceContext) {
+    public Map<String, String> getAllBaggage(@Nullable TraceContext traceContext) {
         return this.braveBaggageManager.getAllBaggage(traceContext);
     }
 
@@ -121,11 +124,13 @@ public class BraveTracer implements Tracer {
     }
 
     @Override
+    @Nullable
     public Baggage getBaggage(String name) {
         return this.braveBaggageManager.getBaggage(name);
     }
 
     @Override
+    @Nullable
     public Baggage getBaggage(TraceContext traceContext, String name) {
         return this.braveBaggageManager.getBaggage(traceContext, name);
     }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/LinkUtils.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/LinkUtils.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.tracing.Link;
 import io.micrometer.tracing.TraceContext;
@@ -74,6 +75,7 @@ class LinkUtils {
             .size();
     }
 
+    @Nullable
     static Link toLink(List<Map.Entry<String, String>> groupedTags) {
         String traceId = "";
         String spanId = "";
@@ -119,6 +121,7 @@ class LinkUtils {
         return fromString[fromString.length == 2 ? 1 : 0];
     }
 
+    @Nullable
     static String tagKeyNameFromString(String tag) {
         Matcher matcher = TAG_KEY.matcher(tag);
         if (matcher.matches()) {

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/EventPublishingContextWrapper.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/EventPublishingContextWrapper.java
@@ -76,6 +76,7 @@ public final class EventPublishingContextWrapper implements Function<ContextStor
         /**
          * Context corresponding to the attached scope. Might be {@code null}.
          */
+        @Nullable
         final Context context;
 
         /**
@@ -86,10 +87,12 @@ public final class EventPublishingContextWrapper implements Function<ContextStor
             this.context = context;
         }
 
+        @Nullable
         public Span getSpan() {
             return Span.fromContextOrNull(context);
         }
 
+        @Nullable
         public Baggage getBaggage() {
             return Baggage.fromContextOrNull(context);
         }
@@ -117,6 +120,7 @@ public final class EventPublishingContextWrapper implements Function<ContextStor
          * {@link Context} corresponding to the scope being restored. Might be
          * {@code null}.
          */
+        @Nullable
         final Context context;
 
         /**
@@ -127,10 +131,12 @@ public final class EventPublishingContextWrapper implements Function<ContextStor
             this.context = context;
         }
 
+        @Nullable
         public Span getSpan() {
             return Span.fromContextOrNull(context);
         }
 
+        @Nullable
         public Baggage getBaggage() {
             return Baggage.fromContextOrNull(context);
         }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageInScope.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageInScope.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.tracing.otel.bridge;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.tracing.BaggageInScope;
@@ -83,6 +84,7 @@ class OtelBaggageInScope implements io.micrometer.tracing.Baggage, BaggageInScop
     }
 
     @Override
+    @Nullable
     public String get() {
         if (entry.get() != null) {
             return entry.get().value;
@@ -91,6 +93,7 @@ class OtelBaggageInScope implements io.micrometer.tracing.Baggage, BaggageInScop
     }
 
     @Override
+    @Nullable
     public String get(TraceContext traceContext) {
         Entry entry = this.otelBaggageManager.getEntry((OtelTraceContext) traceContext, entry().getKey());
         if (entry == null) {
@@ -105,7 +108,7 @@ class OtelBaggageInScope implements io.micrometer.tracing.Baggage, BaggageInScop
         return doSet(this.currentTraceContext.context(), value);
     }
 
-    private io.micrometer.tracing.Baggage doSet(TraceContext context, String value) {
+    private io.micrometer.tracing.Baggage doSet(@Nullable TraceContext context, String value) {
         if (context == null) {
             return this;
         }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageManager.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageManager.java
@@ -87,7 +87,7 @@ public class OtelBaggageManager implements BaggageManager {
     }
 
     @Override
-    public Map<String, String> getAllBaggage(TraceContext traceContext) {
+    public Map<String, String> getAllBaggage(@Nullable TraceContext traceContext) {
         if (traceContext == null) {
             return getAllBaggage();
         }
@@ -98,7 +98,7 @@ public class OtelBaggageManager implements BaggageManager {
         return baggage((OtelTraceContext) currentTraceContext.context());
     }
 
-    private CompositeBaggage baggage(OtelTraceContext traceContext) {
+    private CompositeBaggage baggage(@Nullable OtelTraceContext traceContext) {
         Context context = Context.current();
         Deque<Context> stack = new ArrayDeque<>();
         stack.addFirst(context);
@@ -114,13 +114,14 @@ public class OtelBaggageManager implements BaggageManager {
         return createNewEntryIfMissing(name, entry);
     }
 
-    io.micrometer.tracing.Baggage createNewEntryIfMissing(String name, Entry entry) {
+    io.micrometer.tracing.Baggage createNewEntryIfMissing(String name, @Nullable Entry entry) {
         if (entry == null) {
             return createBaggage(name);
         }
         return otelBaggage(entry);
     }
 
+    @Nullable
     private Entry getBaggage(String name, io.opentelemetry.api.baggage.Baggage baggage) {
         return entryForName(name, baggage);
     }
@@ -147,16 +148,19 @@ public class OtelBaggageManager implements BaggageManager {
         return null;
     }
 
+    @Nullable
     Entry getEntry(OtelTraceContext traceContext, String name) {
         OtelTraceContext context = traceContext;
         Context ctx = context.context();
         return getBaggage(name, Baggage.fromContext(ctx));
     }
 
+    @Nullable
     Context removeFirst(Deque<Context> stack) {
         return stack.isEmpty() ? null : stack.removeFirst();
     }
 
+    @Nullable
     private Entry entryForName(String name, io.opentelemetry.api.baggage.Baggage baggage) {
         return Entry.fromBaggage(baggage)
             .stream()
@@ -265,6 +269,7 @@ class CompositeBaggage implements io.opentelemetry.api.baggage.Baggage {
     }
 
     @Override
+    @Nullable
     public String getEntryValue(String entryKey) {
         return this.entries.stream()
             .filter(entry -> entryKey.equals(entry.getKey()))
@@ -284,11 +289,12 @@ class Entry implements BaggageEntry {
 
     final String key;
 
+    @Nullable
     final String value;
 
     final BaggageEntryMetadata entryMetadata;
 
-    Entry(String key, String value, BaggageEntryMetadata entryMetadata) {
+    Entry(String key, @Nullable String value, BaggageEntryMetadata entryMetadata) {
         this.key = key;
         this.value = value;
         this.entryMetadata = entryMetadata;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelCurrentTraceContext.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelCurrentTraceContext.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.CurrentTraceContext;
 import io.micrometer.tracing.TraceContext;
 import io.opentelemetry.api.baggage.Baggage;
@@ -42,6 +43,7 @@ public class OtelCurrentTraceContext implements CurrentTraceContext {
     private static final ContextKey<OtelTraceContext> OTEL_CONTEXT_KEY = ContextKey.named(TRACING_OTEL_CONTEXT_KEY);
 
     @Override
+    @Nullable
     public TraceContext context() {
         OtelTraceContext otelTraceContext = Context.current().get(OTEL_CONTEXT_KEY);
         if (otelTraceContext != null) {
@@ -65,7 +67,7 @@ public class OtelCurrentTraceContext implements CurrentTraceContext {
      * @return scope that always must be closed
      */
     @Override
-    public Scope newScope(TraceContext context) {
+    public Scope newScope(@Nullable TraceContext context) {
         OtelTraceContext otelTraceContext = (OtelTraceContext) context;
         if (otelTraceContext == null) {
             return new WrappedScope(io.opentelemetry.context.Scope.noop());
@@ -106,7 +108,7 @@ public class OtelCurrentTraceContext implements CurrentTraceContext {
     }
 
     @Override
-    public Scope maybeScope(TraceContext context) {
+    public Scope maybeScope(@Nullable TraceContext context) {
         if (context == null) {
             io.opentelemetry.context.Scope scope = Context.root().makeCurrent();
             return new WrappedScope(scope);
@@ -138,16 +140,18 @@ public class OtelCurrentTraceContext implements CurrentTraceContext {
 
         final io.opentelemetry.context.Scope scope;
 
+        @Nullable
         final OtelTraceContext currentOtelTraceContext;
 
+        @Nullable
         final Context oldContext;
 
         WrappedScope(io.opentelemetry.context.Scope scope) {
             this(scope, null, null);
         }
 
-        WrappedScope(io.opentelemetry.context.Scope scope, OtelTraceContext currentOtelTraceContext,
-                Context oldContext) {
+        WrappedScope(io.opentelemetry.context.Scope scope, @Nullable OtelTraceContext currentOtelTraceContext,
+                @Nullable Context oldContext) {
             this.scope = scope;
             this.currentOtelTraceContext = currentOtelTraceContext;
             this.oldContext = oldContext;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelFinishedSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelFinishedSpan.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.tracing.otel.bridge;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.Link;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
@@ -45,6 +46,7 @@ public class OtelFinishedSpan implements FinishedSpan {
 
     private final MutableSpanData spanData;
 
+    @Nullable
     private volatile String linkLocalIp;
 
     OtelFinishedSpan(SpanData spanData) {
@@ -160,11 +162,13 @@ public class OtelFinishedSpan implements FinishedSpan {
     }
 
     @Override
+    @Nullable
     public String getParentId() {
         return this.spanData.getParentSpanId();
     }
 
     @Override
+    @Nullable
     public String getRemoteIp() {
         return getTags().get(SemanticAttributes.NET_SOCK_PEER_ADDR.getKey());
     }
@@ -191,6 +195,7 @@ public class OtelFinishedSpan implements FinishedSpan {
         return this;
     }
 
+    @Nullable
     private String produceLinkLocalIp() {
         try {
             Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();
@@ -231,6 +236,7 @@ public class OtelFinishedSpan implements FinishedSpan {
     }
 
     @Override
+    @Nullable
     public Throwable getError() {
         Attributes attributes = this.spanData.getEvents()
             .stream()
@@ -261,6 +267,7 @@ public class OtelFinishedSpan implements FinishedSpan {
     }
 
     @Override
+    @Nullable
     public String getRemoteServiceName() {
         return this.spanData.getAttributes().get(AttributeKey.stringKey("peer.service"));
     }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelPropagator.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelPropagator.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.tracing.otel.bridge;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.propagation.Propagator;
@@ -55,7 +56,7 @@ public class OtelPropagator implements Propagator {
     }
 
     @Override
-    public <C> void inject(TraceContext traceContext, C carrier, Setter<C> setter) {
+    public <C> void inject(TraceContext traceContext, @Nullable C carrier, Setter<C> setter) {
         Context context = OtelTraceContext.toOtelContext(traceContext);
         this.propagator.inject(context, carrier, setter::set);
     }
@@ -69,7 +70,7 @@ public class OtelPropagator implements Propagator {
             }
 
             @Override
-            public String get(C carrier, String key) {
+            public String get(@Nullable C carrier, String key) {
                 return getter.get(carrier, key);
             }
         });
@@ -78,7 +79,8 @@ public class OtelPropagator implements Propagator {
         return OtelSpanBuilder.fromOtel(this.tracer).setParent(otelTraceContext);
     }
 
-    private static OtelTraceContext getOtelTraceContext(Context extracted, io.opentelemetry.api.trace.Span span) {
+    private static OtelTraceContext getOtelTraceContext(Context extracted,
+            @Nullable io.opentelemetry.api.trace.Span span) {
         if (span == null || span.equals(io.opentelemetry.api.trace.Span.getInvalid())) {
             io.opentelemetry.api.trace.Span invalid = io.opentelemetry.api.trace.Span.getInvalid();
             return new OtelTraceContext(extracted, invalid.getSpanContext(), invalid);

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
@@ -96,7 +96,7 @@ class OtelSpan implements Span {
     @Override
     public Span event(String value, long time, TimeUnit timeUnit) {
         this.delegate.addEvent(value, time, timeUnit);
-        return null;
+        return this;
     }
 
     @Override

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTraceContext.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTraceContext.java
@@ -37,9 +37,10 @@ public class OtelTraceContext implements TraceContext {
 
     final SpanContext delegate;
 
+    @Nullable
     final Span span;
 
-    OtelTraceContext(Context context, SpanContext delegate, @Nullable Span span) {
+    OtelTraceContext(@Nullable Context context, SpanContext delegate, @Nullable Span span) {
         this(new AtomicReference<>(context == null ? Context.current() : context), delegate, span);
     }
 
@@ -59,7 +60,7 @@ public class OtelTraceContext implements TraceContext {
         this(context(span), span.getSpanContext(), span);
     }
 
-    private static AtomicReference<Context> context(Span span) {
+    private static AtomicReference<Context> context(@Nullable Span span) {
         if (span instanceof SpanFromSpanContext) {
             Context contextFromParent = ((SpanFromSpanContext) span).parentTraceContext.context();
             return new AtomicReference<>(contextFromParent);
@@ -100,6 +101,7 @@ public class OtelTraceContext implements TraceContext {
      * @return OTel version
      * @since 1.1.0
      */
+    @Nullable
     public static SpanContext toOtelSpanContext(TraceContext context) {
         if (context instanceof OtelTraceContext) {
             return ((OtelTraceContext) context).delegate;
@@ -152,7 +154,7 @@ public class OtelTraceContext implements TraceContext {
         return this.delegate;
     }
 
-    void updateContext(Context context) {
+    void updateContext(@Nullable Context context) {
         this.otelContext.set(context);
     }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.tracing.otel.bridge;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.*;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -65,7 +66,7 @@ public class OtelTracer implements Tracer {
     }
 
     @Override
-    public Span nextSpan(Span parent) {
+    public Span nextSpan(@Nullable Span parent) {
         if (parent == null) {
             return nextSpan();
         }
@@ -89,13 +90,13 @@ public class OtelTracer implements Tracer {
     }
 
     @Override
-    public Tracer.SpanInScope withSpan(Span span) {
+    public Tracer.SpanInScope withSpan(@Nullable Span span) {
         TraceContext traceContext = traceContext(span);
         CurrentTraceContext.Scope scope = this.otelCurrentTraceContext.maybeScope(traceContext);
         return new WrappedSpanInScope(scope);
     }
 
-    private TraceContext traceContext(Span span) {
+    private TraceContext traceContext(@Nullable Span span) {
         if (span == null) {
             // remove any existing span/baggage data from the current state of anything
             // that might be holding on to it.
@@ -114,6 +115,7 @@ public class OtelTracer implements Tracer {
     }
 
     @Override
+    @Nullable
     public Span currentSpan() {
         OtelTraceContext context = (OtelTraceContext) this.otelCurrentTraceContext.context();
         if (context != null && context.span != null) {
@@ -161,16 +163,18 @@ public class OtelTracer implements Tracer {
     }
 
     @Override
-    public Map<String, String> getAllBaggage(TraceContext traceContext) {
+    public Map<String, String> getAllBaggage(@Nullable TraceContext traceContext) {
         return this.otelBaggageManager.getAllBaggage(traceContext);
     }
 
     @Override
+    @Nullable
     public Baggage getBaggage(String name) {
         return this.otelBaggageManager.getBaggage(name);
     }
 
     @Override
+    @Nullable
     public Baggage getBaggage(TraceContext traceContext, String name) {
         return this.otelBaggageManager.getBaggage(traceContext, name);
     }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/SpanFromSpanContext.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/SpanFromSpanContext.java
@@ -34,7 +34,7 @@ class SpanFromSpanContext implements io.opentelemetry.api.trace.Span {
 
     final OtelTraceContext parentTraceContext;
 
-    SpanFromSpanContext(io.opentelemetry.api.trace.Span span, SpanContext newSpanContext,
+    SpanFromSpanContext(@Nullable io.opentelemetry.api.trace.Span span, SpanContext newSpanContext,
             OtelTraceContext parentTraceContext) {
         this.span = span != null ? span : io.opentelemetry.api.trace.Span.wrap(newSpanContext);
         this.newSpanContext = newSpanContext;

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/BaggageManager.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/BaggageManager.java
@@ -93,6 +93,7 @@ public interface BaggageManager {
      * @param name baggage name
      * @return baggage if present or creates a new one if missing with {@code null} value
      */
+    @Nullable
     Baggage getBaggage(String name);
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/TraceContext.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/TraceContext.java
@@ -73,6 +73,7 @@ public interface TraceContext {
      * @return {@code true} when sampled, {@code false} when not sampled and {@code null}
      * when sampling decision should be deferred
      */
+    @Nullable
     Boolean sampled();
 
     /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/Tracer.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/Tracer.java
@@ -158,6 +158,7 @@ public interface Tracer extends BaggageManager {
      * @param parent parent span
      * @return a child span for the given parent, {@code null} if context was empty.
      */
+    @Nullable
     Span nextSpan(@Nullable Span parent);
 
     /**


### PR DESCRIPTION
- Added `@Nullable` annotations to methods and fields in micrometer-tracing-bridges directories.
- Added `@Nullable` annotations to `TraceContext.sampled()` and `Tracer.nextSpan(Span)`, since the documents say the functions might return `null.

Fixes #732

---

`FinishedSpan.getKind()` is not annotated with `@Nullable`, but its implementetion might return `null`.  I am no sure whether the implementation or the interface was wrong, so I didn't fix it.

https://github.com/micrometer-metrics/tracing/blob/85a614af3da5cad93240c0c1091f64023a9e15f2/micrometer-tracing/src/main/java/io/micrometer/tracing/exporter/FinishedSpan.java#L181-L184

https://github.com/micrometer-metrics/tracing/blob/bc290c9e2538a3a854a2c1f7d6fbb5b1acabf5f4/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelFinishedSpan.java#L259-L261

https://github.com/micrometer-metrics/tracing/blob/d1383aec471617542558aa20ea8ccb751e26f89b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveFinishedSpan.java#L168-L170
