### PR TITLE
Add "traceSampled" to MDC in the Slf4JEventListener

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/Slf4JEventListener.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/Slf4JEventListener.java
@@ -33,12 +33,16 @@ public class Slf4JEventListener implements EventListener {
 
     private static final String DEFAULT_SPAN_ID_KEY = "spanId";
 
+    private static final String DEFAULT_SAMPLED_KEY = "traceSampled";
+
     private final String traceIdKey;
 
     private final String spanIdKey;
 
+    private final String sampledKey;
+
     public Slf4JEventListener() {
-        this(DEFAULT_TRACE_ID_KEY, DEFAULT_SPAN_ID_KEY);
+        this(DEFAULT_TRACE_ID_KEY, DEFAULT_SPAN_ID_KEY, DEFAULT_SAMPLED_KEY);
     }
 
     /**
@@ -47,8 +51,19 @@ public class Slf4JEventListener implements EventListener {
      * @since 1.1.0
      */
     public Slf4JEventListener(String traceIdKey, String spanIdKey) {
+        this(traceIdKey, spanIdKey, DEFAULT_SAMPLED_KEY);
+    }
+
+    /**
+     * @param traceIdKey custom traceId Key
+     * @param spanIdKey custom spanId Key
+     * @param sampledKey custom sampled Key
+     * @since 1.1.0
+     */
+    public Slf4JEventListener(String traceIdKey, String spanIdKey, String sampledKey) {
         this.traceIdKey = traceIdKey;
         this.spanIdKey = spanIdKey;
+        this.sampledKey = sampledKey;
     }
 
     private void onScopeAttached(EventPublishingContextWrapper.ScopeAttachedEvent event) {
@@ -57,6 +72,7 @@ public class Slf4JEventListener implements EventListener {
         if (span != null) {
             MDC.put(traceIdKey, span.getSpanContext().getTraceId());
             MDC.put(spanIdKey, span.getSpanContext().getSpanId());
+            MDC.put(sampledKey, Boolean.toString(span.getSpanContext().isSampled()));
         }
     }
 
@@ -66,6 +82,7 @@ public class Slf4JEventListener implements EventListener {
         if (span != null) {
             MDC.put(traceIdKey, span.getSpanContext().getTraceId());
             MDC.put(spanIdKey, span.getSpanContext().getSpanId());
+            MDC.put(sampledKey, Boolean.toString(span.getSpanContext().isSampled()));
         }
     }
 
@@ -73,6 +90,7 @@ public class Slf4JEventListener implements EventListener {
         log.trace("Got scope closed event [{}]", event);
         MDC.remove(traceIdKey);
         MDC.remove(spanIdKey);
+        MDC.remove(sampledKey);
     }
 
     @Override

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/Slf4JEventListener.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/Slf4JEventListener.java
@@ -58,7 +58,7 @@ public class Slf4JEventListener implements EventListener {
      * @param traceIdKey custom traceId Key
      * @param spanIdKey custom spanId Key
      * @param sampledKey custom sampled Key
-     * @since 1.1.0
+     * @since 1.4.0
      */
     public Slf4JEventListener(String traceIdKey, String spanIdKey, String sampledKey) {
         this.traceIdKey = traceIdKey;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelTracingApiTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelTracingApiTests.java
@@ -268,7 +268,8 @@ class OtelTracingApiTests {
         String customTraceIdKey = "customTraceId";
         String customSpanIdKey = "customSpanId";
         String customSampledKey = "customTraceSampled";
-        Slf4JEventListener customSlf4JEventListener = new Slf4JEventListener(customTraceIdKey, customSpanIdKey, customSampledKey);
+        Slf4JEventListener customSlf4JEventListener = new Slf4JEventListener(customTraceIdKey, customSpanIdKey,
+                customSampledKey);
 
         Span newSpan = this.tracer.nextSpan().name("testMDC");
         try (Tracer.SpanInScope ws = this.tracer.withSpan(newSpan.start())) {

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelTracingApiTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelTracingApiTests.java
@@ -267,7 +267,8 @@ class OtelTracingApiTests {
     void testSlf4JEventListener() {
         String customTraceIdKey = "customTraceId";
         String customSpanIdKey = "customSpanId";
-        Slf4JEventListener customSlf4JEventListener = new Slf4JEventListener(customTraceIdKey, customSpanIdKey);
+        String customSampledKey = "customTraceSampled";
+        Slf4JEventListener customSlf4JEventListener = new Slf4JEventListener(customTraceIdKey, customSpanIdKey, customSampledKey);
 
         Span newSpan = this.tracer.nextSpan().name("testMDC");
         try (Tracer.SpanInScope ws = this.tracer.withSpan(newSpan.start())) {
@@ -292,6 +293,13 @@ class OtelTracingApiTests {
             then(customSpanId).isNotBlank();
             then(spanId).isEqualTo(customSpanId);
 
+            String sampled = MDC.get("traceSampled");
+            String customSampled = MDC.get(customSampledKey);
+
+            then(sampled).isNotBlank();
+            then(customSampled).isNotBlank();
+            then(sampled).isEqualTo(customSampled);
+
             EventPublishingContextWrapper.ScopeRestoredEvent scopeRestoredEvent = new EventPublishingContextWrapper.ScopeRestoredEvent(
                     current);
             slf4JEventListener.onEvent(scopeRestoredEvent);
@@ -310,6 +318,13 @@ class OtelTracingApiTests {
             then(spanId).isNotBlank();
             then(customSpanId).isNotBlank();
             then(spanId).isEqualTo(customSpanId);
+
+            sampled = MDC.get("traceSampled");
+            customSampled = MDC.get(customSampledKey);
+
+            then(sampled).isNotBlank();
+            then(customSampled).isNotBlank();
+            then(sampled).isEqualTo(customSampled);
         }
         finally {
             newSpan.end();
@@ -323,6 +338,8 @@ class OtelTracingApiTests {
         then(MDC.get(customTraceIdKey)).isNull();
         then(MDC.get("spanId")).isNull();
         then(MDC.get(customSpanIdKey)).isNull();
+        then(MDC.get("traceSampled")).isNull();
+        then(MDC.get(customSampledKey)).isNull();
 
     }
 


### PR DESCRIPTION
This resolves https://github.com/micrometer-metrics/tracing/issues/755

As mentioned this is useful for filtering by looks which will also appear in the tracing tool. 

API is backwards compatible and tests are added. 

Put "since 1.4.0" on the new constructor, assuming this will be part of next minor release. Happy to change that.