### PR TITLE
Use TestObservationRegistry in context propagation tests

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/contextpropagation/NestedScopesTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/contextpropagation/NestedScopesTests.java
@@ -20,6 +20,7 @@ import brave.test.TestSpanHandler;
 import io.micrometer.context.ContextSnapshot;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import io.micrometer.tracing.CurrentTraceContext.Scope;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
@@ -44,7 +45,7 @@ class NestedScopesTests {
 
     DefaultTracingObservationHandler handler = new DefaultTracingObservationHandler(tracer);
 
-    ObservationRegistry observationRegistry = ObservationRegistry.create();
+    ObservationRegistry observationRegistry = TestObservationRegistry.create();
 
     @BeforeEach
     void setup() {

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/contextpropagation/NestedScopesTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/contextpropagation/NestedScopesTests.java
@@ -18,6 +18,7 @@ package io.micrometer.tracing.otel.contextpropagation;
 import io.micrometer.context.ContextSnapshot;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import io.micrometer.tracing.CurrentTraceContext.Scope;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
@@ -59,7 +60,7 @@ class NestedScopesTests {
 
     DefaultTracingObservationHandler handler = new DefaultTracingObservationHandler(tracer);
 
-    ObservationRegistry observationRegistry = ObservationRegistry.create();
+    ObservationRegistry observationRegistry = TestObservationRegistry.create();
 
     @BeforeEach
     void setup() {

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/contextpropagation/ScopesTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/contextpropagation/ScopesTests.java
@@ -24,6 +24,7 @@ import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import io.micrometer.tracing.BaggageInScope;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
@@ -71,7 +72,7 @@ class ScopesTests {
 
     DefaultTracingObservationHandler handler = new DefaultTracingObservationHandler(tracer);
 
-    ObservationRegistry observationRegistry = ObservationRegistry.create();
+    ObservationRegistry observationRegistry = TestObservationRegistry.create();
 
     @BeforeEach
     void setup() {


### PR DESCRIPTION
This change allows to leverage [`ObservationValidator`](https://github.com/micrometer-metrics/micrometer/pull/5300) and can help improve the `NullObservation` implementation. Currently the tests should fail so it's best to delay merging until `NullObservation` interoperability with `ObservationValidator` is improved.