### PR TITLE
Support list values in tags in Span and SpanCustomizer

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BraveFinishedSpanTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BraveFinishedSpanTests.java
@@ -16,6 +16,7 @@
 package io.micrometer.tracing.brave.bridge;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -80,9 +81,14 @@ class BraveFinishedSpanTests {
 
         Map<String, Object> map = new HashMap<>();
         map.put("foo", 2L);
+        map.put("bar", Arrays.asList("a", "b", "c"));
+        map.put("baz", Arrays.asList(1, 2, 3));
         span.setTypedTags(map);
 
-        then(span.getTypedTags().get("foo")).isEqualTo("2");
+        then(span.getTypedTags()).hasSize(3)
+            .containsEntry("foo", "2")
+            .containsEntry("bar", "a,b,c")
+            .containsEntry("baz", "1,2,3");
     }
 
     @Test

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BraveSpanBuilderTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BraveSpanBuilderTests.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.tracing.brave.bridge;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -83,6 +84,21 @@ class BraveSpanBuilderTests {
             .containsEntry("double", "2.5")
             .containsEntry("long", "2")
             .containsEntry("boolean", "true");
+    }
+
+    @Test
+    void should_set_multi_value_tags() {
+        new BraveSpanBuilder(tracing.tracer()).tagOfStrings("strings", Arrays.asList("s1", "s2", "s3"))
+            .tagOfDoubles("doubles", Arrays.asList(1.0, 2.5, 3.7))
+            .tagOfLongs("longs", Arrays.asList(2L, 3L, 4L))
+            .tagOfBooleans("booleans", Arrays.asList(true, false, false))
+            .start()
+            .end();
+
+        then(handler.get(0).tags()).containsEntry("strings", "s1,s2,s3")
+            .containsEntry("doubles", "1.0,2.5,3.7")
+            .containsEntry("longs", "2,3,4")
+            .containsEntry("booleans", "true,false,false");
     }
 
     private Map<String, Object> tags() {

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BraveSpanTest.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/test/java/io/micrometer/tracing/brave/bridge/BraveSpanTest.java
@@ -20,6 +20,8 @@ import brave.test.TestSpanHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BraveSpanTest {
@@ -46,6 +48,21 @@ public class BraveSpanTest {
             .containsEntry("double", "2.5")
             .containsEntry("long", "2")
             .containsEntry("boolean", "true");
+    }
+
+    @Test
+    void should_set_multi_value_tags() {
+        new BraveSpan(tracing.tracer().nextSpan()).start()
+            .tagOfStrings("strings", Arrays.asList("s1", "s2", "s3"))
+            .tagOfDoubles("doubles", Arrays.asList(1.0, 2.5, 3.7))
+            .tagOfLongs("longs", Arrays.asList(2L, 3L, 4L))
+            .tagOfBooleans("booleans", Arrays.asList(true, false, false))
+            .end();
+
+        assertThat(handler.get(0).tags()).containsEntry("strings", "s1,s2,s3")
+            .containsEntry("doubles", "1.0,2.5,3.7")
+            .containsEntry("longs", "2,3,4")
+            .containsEntry("booleans", "true,false,false");
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelFinishedSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelFinishedSpan.java
@@ -129,6 +129,23 @@ public class OtelFinishedSpan implements FinishedSpan {
         else if (value instanceof Boolean) {
             return AttributeKey.booleanKey(key);
         }
+        else if (value instanceof List) {
+            List<?> valueAsList = (List<?>) value;
+            if (valueAsList.isEmpty()) {
+                return AttributeKey.stringArrayKey(key);
+            }
+            Object firstValue = valueAsList.get(0);
+            if (firstValue instanceof Double) {
+                return AttributeKey.doubleArrayKey(key);
+            }
+            else if (firstValue instanceof Long) {
+                return AttributeKey.longArrayKey(key);
+            }
+            else if (firstValue instanceof Boolean) {
+                return AttributeKey.doubleArrayKey(key);
+            }
+            return AttributeKey.stringArrayKey(key);
+        }
         return AttributeKey.stringKey(key);
     }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
@@ -16,10 +16,12 @@
 package io.micrometer.tracing.otel.bridge;
 
 import io.micrometer.tracing.Span;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.semconv.SemanticAttributes;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -120,6 +122,30 @@ class OtelSpan implements Span {
     @Override
     public Span tag(String key, boolean value) {
         this.delegate.setAttribute(key, value);
+        return new OtelSpan(this.delegate);
+    }
+
+    @Override
+    public Span tagOfStrings(String key, List<String> values) {
+        this.delegate.setAttribute(AttributeKey.stringArrayKey(key), values);
+        return new OtelSpan(this.delegate);
+    }
+
+    @Override
+    public Span tagOfLongs(String key, List<Long> values) {
+        this.delegate.setAttribute(AttributeKey.longArrayKey(key), values);
+        return new OtelSpan(this.delegate);
+    }
+
+    @Override
+    public Span tagOfDoubles(String key, List<Double> values) {
+        this.delegate.setAttribute(AttributeKey.doubleArrayKey(key), values);
+        return new OtelSpan(this.delegate);
+    }
+
+    @Override
+    public Span tagOfBooleans(String key, List<Boolean> values) {
+        this.delegate.setAttribute(AttributeKey.booleanArrayKey(key), values);
         return new OtelSpan(this.delegate);
     }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilder.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilder.java
@@ -124,6 +124,30 @@ class OtelSpanBuilder implements Span.Builder {
     }
 
     @Override
+    public Span.Builder tagOfStrings(String key, List<String> values) {
+        this.attributes.put(AttributeKey.stringArrayKey(key), values);
+        return this;
+    }
+
+    @Override
+    public Span.Builder tagOfLongs(String key, List<Long> values) {
+        this.attributes.put(AttributeKey.longArrayKey(key), values);
+        return this;
+    }
+
+    @Override
+    public Span.Builder tagOfDoubles(String key, List<Double> values) {
+        this.attributes.put(AttributeKey.doubleArrayKey(key), values);
+        return this;
+    }
+
+    @Override
+    public Span.Builder tagOfBooleans(String key, List<Boolean> values) {
+        this.attributes.put(AttributeKey.booleanArrayKey(key), values);
+        return this;
+    }
+
+    @Override
     public Span.Builder error(Throwable throwable) {
         this.error = throwable;
         return this;

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelFinishedSpanTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelFinishedSpanTests.java
@@ -70,9 +70,16 @@ class OtelFinishedSpanTests {
 
         Map<String, Object> map = new HashMap<>();
         map.put("foo", 2L);
+        map.put("bar", Arrays.asList("a", "b", "c"));
+        map.put("baz", Arrays.asList(1, 2, 3));
+        map.put("qux", Collections.emptyList());
         span.setTypedTags(map);
 
-        then(span.getTypedTags().get("foo")).isEqualTo(2L);
+        then(span.getTypedTags()).hasSize(4)
+            .containsEntry("foo", 2L)
+            .containsEntry("bar", Arrays.asList("a", "b", "c"))
+            .containsEntry("baz", Arrays.asList(1, 2, 3))
+            .containsEntry("qux", Collections.emptyList());
     }
 
     @Test

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilderTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilderTests.java
@@ -19,6 +19,7 @@ import io.micrometer.tracing.Link;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -26,6 +27,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -102,6 +104,24 @@ class OtelSpanBuilderTests {
         then(poll.getAttributes().get(AttributeKey.doubleKey("double"))).isEqualTo(2.5);
         then(poll.getAttributes().get(AttributeKey.longKey("long"))).isEqualTo(2L);
         then(poll.getAttributes().get(AttributeKey.booleanKey("boolean"))).isTrue();
+    }
+
+    @Test
+    void should_set_multi_value_tags() {
+        new OtelSpanBuilder(otelTracer).name("foo")
+            .tagOfStrings("strings", Arrays.asList("s1", "s2", "s3"))
+            .tagOfDoubles("doubles", Arrays.asList(1.0, 2.5, 3.7))
+            .tagOfLongs("longs", Arrays.asList(2L, 3L, 4L))
+            .tagOfBooleans("booleans", Arrays.asList(true, false, false))
+            .start()
+            .end();
+
+        SpanData poll = processor.spans().poll();
+        Attributes attributes = poll.getAttributes();
+        then(attributes.get(AttributeKey.stringArrayKey("strings"))).isEqualTo(Arrays.asList("s1", "s2", "s3"));
+        then(attributes.get(AttributeKey.doubleArrayKey("doubles"))).isEqualTo(Arrays.asList(1.0, 2.5, 3.7));
+        then(attributes.get(AttributeKey.longArrayKey("longs"))).isEqualTo(Arrays.asList(2L, 3L, 4L));
+        then(attributes.get(AttributeKey.booleanArrayKey("booleans"))).isEqualTo(Arrays.asList(true, false, false));
     }
 
     @Test

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/Span.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/Span.java
@@ -16,8 +16,9 @@
 package io.micrometer.tracing;
 
 import io.micrometer.tracing.propagation.Propagator;
-
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * This API was heavily influenced by Brave. Parts of its documentation were taken
@@ -179,6 +180,46 @@ public interface Span extends io.micrometer.tracing.SpanCustomizer {
      */
     default Span tag(String key, boolean value) {
         return tag(key, String.valueOf(value));
+    }
+
+    /**
+     * Sets a tag on this span.
+     * @param key tag key
+     * @param values tag values
+     * @return this span
+     */
+    default Span tagOfStrings(String key, List<String> values) {
+        return tag(key, String.join(",", values));
+    }
+
+    /**
+     * Sets a tag on this span.
+     * @param key tag key
+     * @param values tag values
+     * @return this span
+     */
+    default Span tagOfLongs(String key, List<Long> values) {
+        return tag(key, values.stream().map(String::valueOf).collect(Collectors.joining(",")));
+    }
+
+    /**
+     * Sets a tag on this span.
+     * @param key tag key
+     * @param values tag values
+     * @return this span
+     */
+    default Span tagOfDoubles(String key, List<Double> values) {
+        return tag(key, values.stream().map(String::valueOf).collect(Collectors.joining(",")));
+    }
+
+    /**
+     * Sets a tag on this span.
+     * @param key tag key
+     * @param values tag values
+     * @return this span
+     */
+    default Span tagOfBooleans(String key, List<Boolean> values) {
+        return tag(key, values.stream().map(String::valueOf).collect(Collectors.joining(",")));
     }
 
     /**
@@ -391,6 +432,46 @@ public interface Span extends io.micrometer.tracing.SpanCustomizer {
          */
         default Builder tag(String key, boolean value) {
             return tag(key, String.valueOf(value));
+        }
+
+        /**
+         * Sets a tag on this span.
+         * @param key tag key
+         * @param values tag values
+         * @return this
+         */
+        default Builder tagOfStrings(String key, List<String> values) {
+            return tag(key, String.join(",", values));
+        }
+
+        /**
+         * Sets a tag on this span.
+         * @param key tag key
+         * @param values tag values
+         * @return this
+         */
+        default Builder tagOfLongs(String key, List<Long> values) {
+            return tag(key, values.stream().map(String::valueOf).collect(Collectors.joining(",")));
+        }
+
+        /**
+         * Sets a tag on this span.
+         * @param key tag key
+         * @param values tag values
+         * @return this
+         */
+        default Builder tagOfDoubles(String key, List<Double> values) {
+            return tag(key, values.stream().map(String::valueOf).collect(Collectors.joining(",")));
+        }
+
+        /**
+         * Sets a tag on this span.
+         * @param key tag key
+         * @param values tag values
+         * @return this
+         */
+        default Builder tagOfBooleans(String key, List<Boolean> values) {
+            return tag(key, values.stream().map(String::valueOf).collect(Collectors.joining(",")));
         }
 
         /**

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/exporter/FinishedSpan.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/exporter/FinishedSpan.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.tracing.Link;
@@ -90,7 +91,14 @@ public interface FinishedSpan {
      */
     default FinishedSpan setTypedTags(Map<String, Object> tags) {
         Map<String, String> map = new HashMap<>();
-        tags.forEach((s, o) -> map.put(s, String.valueOf(o)));
+        tags.forEach((s, o) -> {
+            if (o instanceof List) {
+                map.put(s, ((List<?>) o).stream().map(Object::toString).collect(Collectors.joining(",")));
+            }
+            else {
+                map.put(s, String.valueOf(o));
+            }
+        });
         return setTags(map);
     }
 


### PR DESCRIPTION
Resolves #785.

I've named the functions `tagOfStrings`, `tagOfDoubles`, etc., because `tag` would lead to clashes due to type erasure. 