### PR TITLE
Allow for recording an error in spans without throwables

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveSpan.java
@@ -115,6 +115,12 @@ public class BraveSpan implements Span {
     }
 
     @Override
+    public Span error(String message) {
+        this.delegate.tag("error", message);
+        return this;
+    }
+
+    @Override
     public void end() {
         this.delegate.finish();
     }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
@@ -17,11 +17,13 @@ package io.micrometer.tracing.otel.bridge;
 
 import io.micrometer.tracing.Span;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.semconv.SemanticAttributes;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +35,8 @@ import java.util.concurrent.TimeUnit;
  * @since 1.0.0
  */
 public class OtelSpan implements Span {
+
+    private static final AttributeKey<String> ERROR_MESSAGE = AttributeKey.stringKey("error.message");
 
     final io.opentelemetry.api.trace.Span delegate;
 
@@ -169,6 +173,14 @@ public class OtelSpan implements Span {
     public Span error(Throwable throwable) {
         this.delegate.recordException(throwable);
         this.delegate.setStatus(StatusCode.ERROR, throwable.getMessage());
+        return this;
+    }
+
+    @Override
+    public Span error(String message) {
+        Attributes attributes = Attributes.of(ERROR_MESSAGE, message);
+        this.delegate.setStatus(StatusCode.ERROR, message);
+        this.delegate.addEvent(message, attributes, Instant.now());
         return this;
     }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelSpanTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelSpanTests.java
@@ -60,6 +60,18 @@ class OtelSpanTests {
     }
 
     @Test
+    void should_set_status_to_error_when_recording_error() {
+        OtelSpan otelSpan = new OtelSpan(otelTracer.spanBuilder("foo").startSpan());
+
+        otelSpan.error("boom!").end();
+
+        SpanData poll = arrayListSpanProcessor.spans().poll();
+        then(poll.getStatus()).isEqualTo(StatusData.create(StatusCode.ERROR, "boom!"));
+        then(poll.getEvents()).hasSize(1);
+        then(poll.getEvents().get(0).getAttributes().asMap().values()).containsAnyOf("boom!");
+    }
+
+    @Test
     void should_be_equal_when_two_span_delegates_are_equal() {
         Span span = otelTracer.spanBuilder("foo").startSpan();
         OtelSpan otelSpan = new OtelSpan(span);

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleSpan.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleSpan.java
@@ -122,6 +122,11 @@ public class SimpleSpan implements Span, FinishedSpan {
     }
 
     @Override
+    public Span error(String message) {
+        return this;
+    }
+
+    @Override
     public SimpleSpan remoteIpAndPort(String ip, int port) {
         this.ip = ip;
         this.port = port;

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/Span.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/Span.java
@@ -78,6 +78,11 @@ public interface Span extends io.micrometer.tracing.SpanCustomizer {
         }
 
         @Override
+        public Span error(String message) {
+            return this;
+        }
+
+        @Override
         public void end() {
 
         }
@@ -228,6 +233,13 @@ public interface Span extends io.micrometer.tracing.SpanCustomizer {
      * @return this span
      */
     Span error(Throwable throwable);
+
+    /**
+     * Records an error in this span.
+     * @param message to record
+     * @return this span
+     */
+    Span error(String message);
 
     /**
      * Ends the span. The span gets stopped and recorded if not noop.


### PR DESCRIPTION
Hey! It would be really nice if we could attach error events to spans without having to pass `Throwable`s around. This is an attempt to cater for a more functional style of programming where exceptions are avoided and errors are part of methods' signatures.

I'm unsure whether `this.delegate.tag("error", message);` is enough for the Brave bridge. I didn't find many options in the native API.

Thanks for considering this proposal!