### PR TITLE
Replace deprecated Project.task()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ subprojects {
 			}
 		}
 
-		task dockerTest(type: Test) {
+		tasks.register('dockerTest', Test) {
 			// set heap size for the test JVM(s)
 			maxHeapSize = '1500m'
 

--- a/docs/src/test/resources/docs-generator-build.gradle
+++ b/docs/src/test/resources/docs-generator-build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	adoc "io.micrometer:micrometer-docs-generator:$micrometerDocsVersion"
 }
 
-task generateObservabilityDocs(type: JavaExec) {
+tasks.register('generateObservabilityDocs', JavaExec) {
 	mainClass = "io.micrometer.docs.DocsGeneratorCommand"
 	classpath configurations.adoc
 	// input folder, inclusion pattern, output folder


### PR DESCRIPTION
This PR replaces deprecated `Project.task()` with `tasks.register()`.

See https://docs.gradle.org/current/userguide/upgrading_version_8.html#source_level_deprecation_of_project_task_methods