### PR TITLE
perf(tracing): short circuit matching baggage key values

### DIFF
--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/handler/RevertingScope.java
@@ -110,6 +110,11 @@ class RevertingScope implements CurrentTraceContext.Scope {
         for (String remoteField : tracer.getBaggageFields()) {
             lowerCaseRemoteFields.add(remoteField.toLowerCase());
         }
+
+        if (lowerCaseRemoteFields.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         Collection<KeyValue> baggageKeyValues = new ArrayList<>();
         for (KeyValue keyValue : context.getAllKeyValues()) {
             if (lowerCaseRemoteFields.contains(keyValue.getKey().toLowerCase())) {


### PR DESCRIPTION
_Note that when I talk about spring boot (SB) versions below, I always mean the respective micrometer-metrics/tracing versions based on whatever spring boot pulls in._

In our application, which is a spring cloud gateway with spring security and various micrometer based metrics, we see CPU increase by almost 20 percentage points when upgrading from SB 3.3.11 to 3.4.5.

Thanks to flight recorder, this was pinned down to new code introduced with https://github.com/micrometer-metrics/tracing/pull/688

In our case, the method `TracingObservationHandler.setMaybeScopeOnTracingContext` is called about 100 times per request. This happens for both SB 3.3.11 and SB 3.4.5. But the PR linked above now calls out to `RevertingScope.maybeWithBaggage`, which seems to be quite heavy.

Method profiling from JDK Mission Control:

![image](https://github.com/user-attachments/assets/713040cf-1cbc-4385-8d2c-3ffd2d6cb9e4)

Stacktrace for that top method:

![image](https://github.com/user-attachments/assets/1b1a428b-0e96-442b-871b-1a1c5c65e83c)

In our case, this call is not needed at all, because the tracer has no baggage fields. This proposed change short-circuits in the method `matchingBaggageKeyValues` to avoid the expensive `context.getAllKeyValues` call.

Following are three key metrics that show the significance of this PR. The first block is a performance test run with this change. The CPU is slightly below 60%. The second block starting at around 15:00 is "vanilla" SB 3.4.5 , which makes the CPU go up to almost 80%. Below are two more metrics where a clear difference is visible.

![image](https://github.com/user-attachments/assets/d7769af8-d6fe-4841-a763-b7c85bcc0bde)

I can provide more data if you want, but this feels like low-hanging fruit to me so hopefully this can be accepted as a change :) I have created this PR against main, but would be great if you're accepting it, if it could be backported to micrometer 1.4.x such that we can upgrade to SB 3.4.x. I'll be happy to create another PR.