### PR TITLE
Support extraction of all values for a single key

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelPropagator.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelPropagator.java
@@ -26,6 +26,8 @@ import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -75,6 +77,14 @@ public class OtelPropagator implements Propagator {
                     return null;
                 }
                 return getter.get(carrier, key);
+            }
+
+            @Override
+            public Iterator<String> getAll(@Nullable C carrier, String key) {
+                if (carrier == null) {
+                    return Collections.emptyIterator();
+                }
+                return getter.getAll(carrier, key).iterator();
             }
         });
         io.opentelemetry.api.trace.Span span = io.opentelemetry.api.trace.Span.fromContextOrNull(extracted);

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/propagation/Propagator.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/propagation/Propagator.java
@@ -155,6 +155,30 @@ public interface Propagator {
          */
         @Nullable String get(C carrier, String key);
 
+        /**
+         * Get all values of the given propagation {@code key}, if any exist. This should
+         * only be used when it is expected that the key may be repeated.
+         * {@link #get(Object, String)} should be preferred in other cases for
+         * performance.
+         * @param carrier carrier of propagation fields, such as an http request.
+         * @param key the key of the field.
+         * @return all values of the given propagation {@code key} or returns an empty
+         * {@code Iterable} if no values are found.
+         * @implNote For backward-compatibility, a default implementation is provided that
+         * returns a list with the value of {@link #get(Object, String)} or an empty list
+         * if no values are found. Implementors of this interface should override this
+         * method to provide an implementation that returns all present values of the
+         * given propagation {@code key}.
+         * @since 1.6.0
+         */
+        default Iterable<String> getAll(C carrier, String key) {
+            String firstValue = get(carrier, key);
+            if (firstValue == null) {
+                return Collections.emptyList();
+            }
+            return Collections.singletonList(firstValue);
+        }
+
     }
 
 }


### PR DESCRIPTION
Adds a new method getAll to get all values for a key from a carrier. This mirrors the API in the Micrometer Observation module for the same named Getter interface. This updates the places where adapting between the corresponding APIs happens: observation <-> tracing and tracing <-> otel.

Resolves gh-1032