### PR TITLE
Allow setting a null baggage value

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageInScope.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-brave/src/main/java/io/micrometer/tracing/brave/bridge/BraveBaggageInScope.java
@@ -103,7 +103,7 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
 
     @Override
     @Deprecated
-    public Baggage set(TraceContext traceContext, String value) {
+    public Baggage set(TraceContext traceContext, @Nullable String value) {
         brave.propagation.TraceContext braveContext = updateBraveTraceContext(traceContext);
         boolean success = this.delegate.updateValue(braveContext, value);
         if (logger.isTraceEnabled()) {
@@ -131,7 +131,7 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
     }
 
     @Override
-    public BaggageInScope makeCurrent(String value) {
+    public BaggageInScope makeCurrent(@Nullable String value) {
         if (this.traceContext != null) {
             boolean success = this.delegate.updateValue(this.traceContext, value);
             if (logger.isTraceEnabled()) {
@@ -149,7 +149,7 @@ class BraveBaggageInScope implements Baggage, BaggageInScope {
     }
 
     @Override
-    public BaggageInScope makeCurrent(TraceContext traceContext, String value) {
+    public BaggageInScope makeCurrent(TraceContext traceContext, @Nullable String value) {
         brave.propagation.TraceContext braveContext = updateBraveTraceContext(traceContext);
         boolean success = this.delegate.updateValue(braveContext, value);
         if (logger.isTraceEnabled()) {

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageInScope.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelBaggageInScope.java
@@ -154,17 +154,17 @@ class OtelBaggageInScope implements io.micrometer.tracing.Baggage, BaggageInScop
 
     @Override
     @Deprecated
-    public io.micrometer.tracing.Baggage set(TraceContext traceContext, String value) {
+    public io.micrometer.tracing.Baggage set(TraceContext traceContext, @Nullable String value) {
         return doSet(traceContext, value);
     }
 
     @Override
-    public BaggageInScope makeCurrent(String value) {
+    public BaggageInScope makeCurrent(@Nullable String value) {
         return doSet(currentTraceContext.context(), value).makeCurrent();
     }
 
     @Override
-    public BaggageInScope makeCurrent(TraceContext traceContext, String value) {
+    public BaggageInScope makeCurrent(TraceContext traceContext, @Nullable String value) {
         return doSet(traceContext, value).makeCurrent();
     }
 

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageInScope.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/main/java/io/micrometer/tracing/test/simple/SimpleBaggageInScope.java
@@ -110,20 +110,20 @@ public class SimpleBaggageInScope implements Baggage, BaggageInScope {
 
     @Override
     @Deprecated
-    public Baggage set(TraceContext traceContext, String value) {
+    public Baggage set(TraceContext traceContext, @Nullable String value) {
         this.value = value;
         this.traceContext = traceContext;
         return this;
     }
 
     @Override
-    public BaggageInScope makeCurrent(String value) {
+    public BaggageInScope makeCurrent(@Nullable String value) {
         this.value = value;
         return makeCurrent();
     }
 
     @Override
-    public BaggageInScope makeCurrent(TraceContext traceContext, String value) {
+    public BaggageInScope makeCurrent(TraceContext traceContext, @Nullable String value) {
         this.value = value;
         this.traceContext = traceContext;
         return makeCurrent();

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/Baggage.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/Baggage.java
@@ -57,7 +57,7 @@ public interface Baggage extends BaggageView {
         }
 
         @Override
-        public Baggage set(TraceContext traceContext, String value) {
+        public Baggage set(TraceContext traceContext, @Nullable String value) {
             return this;
         }
 
@@ -67,12 +67,12 @@ public interface Baggage extends BaggageView {
         }
 
         @Override
-        public BaggageInScope makeCurrent(String value) {
+        public BaggageInScope makeCurrent(@Nullable String value) {
             return BaggageInScope.NOOP;
         }
 
         @Override
-        public BaggageInScope makeCurrent(TraceContext traceContext, String value) {
+        public BaggageInScope makeCurrent(TraceContext traceContext, @Nullable String value) {
             return BaggageInScope.NOOP;
         }
     };
@@ -94,7 +94,7 @@ public interface Baggage extends BaggageView {
      * @deprecated use {@link Baggage#makeCurrent(TraceContext, String)}
      */
     @Deprecated
-    Baggage set(TraceContext traceContext, String value);
+    Baggage set(TraceContext traceContext, @Nullable String value);
 
     /**
      * Sets the current baggage in scope.
@@ -107,7 +107,7 @@ public interface Baggage extends BaggageView {
      * @param value to set
      * @return a {@link BaggageInScope} instance
      */
-    default BaggageInScope makeCurrent(String value) {
+    default BaggageInScope makeCurrent(@Nullable String value) {
         return set(value).makeCurrent();
     }
 
@@ -117,7 +117,7 @@ public interface Baggage extends BaggageView {
      * @param value to set
      * @return a {@link BaggageInScope} instance
      */
-    default BaggageInScope makeCurrent(TraceContext traceContext, String value) {
+    default BaggageInScope makeCurrent(TraceContext traceContext, @Nullable String value) {
         return set(traceContext, value).makeCurrent();
     }
 


### PR DESCRIPTION
Setting null has been allowed (although not tested or documented) since before we added nullability. This marks the API nullability accordingly.

TODO: We should add tests and documentation for this.