### PR TITLE
Add @BaggageKeyValue annotation for baggage scope management

### DIFF
--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -82,7 +82,7 @@ include::{include-bridges-java}/micrometer-tracing-bridge-otel/src/test/java/io/
 
 == Aspect Oriented Programming
 
-Micrometer Tracing contains `@NewSpan`, `@ContinueSpan`, and `@SpanTag` annotations that frameworks can use to create or customize spans for either specific types of methods such as those serving web request endpoints or, more generally, to all methods.
+Micrometer Tracing contains `@NewSpan`, `@ContinueSpan`, `@SpanTag`, and `@BaggageKeyValue` annotations that frameworks can use to create or customize spans for either specific types of methods such as those serving web request endpoints or, more generally, to all methods.
 
 WARNING: Micrometer's Spring Boot configuration does _not_ recognize these aspects on arbitrary methods.
 
@@ -106,4 +106,73 @@ include::{include-java}/tracing/TracingSpanAspectTests.java[tags=example,indent=
 include::{include-java}/tracing/TracingSpanAspectTests.java[tags=usage_example,indent=0]
 
 -----
+
+=== `@BaggageKeyValue` Annotation
+
+The `@BaggageKeyValue` annotation can be placed on method parameters to automatically put the parameter value into baggage scope for the duration of the method execution. The baggage scope is automatically closed when the method completes, preventing memory leaks.
+
+There are three ways to resolve the baggage value, with the following precedence:
+
+1. **Resolver**: Use a `ValueResolver` implementation (highest precedence)
+2. **Expression**: Evaluate an expression (e.g. SpEL when using Spring)
+3. **toString()**: Use the `toString()` value of the parameter (default)
+
+[source,java]
+-----
+// The parameter value will be put into baggage with name "userId" for the duration of the method
+@NewSpan
+public void processOrder(@BaggageKeyValue("userId") String userId) {
+    // The baggage "userId" is available in scope here
+    // It will be automatically closed when the method returns
+}
+
+// The 'key' attribute is an alias for 'value'
+@NewSpan
+public void processWithKey(@BaggageKeyValue(key = "tenantId") String tenant) {
+    // The baggage "tenantId" is in scope
+}
+
+// Multiple baggage entries can be added
+@NewSpan
+public void processRequest(@BaggageKeyValue("requestId") String requestId,
+                           @BaggageKeyValue("tenantId") String tenantId) {
+    // Both "requestId" and "tenantId" are in baggage scope
+}
+
+// Use an expression to extract a value from a complex object
+@NewSpan
+public void processOrder(@BaggageKeyValue(value = "orderId", expression = "id") Order order) {
+    // The baggage "orderId" is set to the result of evaluating "id" on the Order object
+}
+
+// Use a custom resolver for full control over the value
+@NewSpan
+public void processOrder(@BaggageKeyValue(value = "orderInfo", resolver = OrderResolver.class) Order order) {
+    // The baggage "orderInfo" is set to the value returned by OrderResolver
+}
+-----
+
+NOTE: The `@BaggageKeyValue` annotation requires the method to also be annotated with `@NewSpan` or `@ContinueSpan` so that it is intercepted by the `SpanAspect`.
+
+To enable `@BaggageKeyValue` support with expression and resolver capabilities, pass the resolver providers to the `ImperativeMethodInvocationProcessor`. The preferred approach is to use the 5-arg constructor so that both `@SpanTag` and `@BaggageKeyValue` share the same resolver providers:
+
+[source,java]
+-----
+// Preferred: pass resolver providers so both @SpanTag and @BaggageKeyValue can use them
+ImperativeMethodInvocationProcessor processor = new ImperativeMethodInvocationProcessor(
+    newSpanParser, tracer, spanTagAnnotationHandler,
+    resolverProvider, expressionResolverProvider);
+-----
+
+Alternatively, you can construct a `BaggageKeyValueAnnotationHandler` directly and use the 4-arg constructor:
+
+[source,java]
+-----
+BaggageKeyValueAnnotationHandler baggageHandler = new BaggageKeyValueAnnotationHandler(
+    resolverProvider, expressionResolverProvider);
+ImperativeMethodInvocationProcessor processor = new ImperativeMethodInvocationProcessor(
+    newSpanParser, tracer, spanTagAnnotationHandler, baggageHandler);
+-----
+
+TIP: In a Spring application, `resolverProvider` and `expressionResolverProvider` are typically `beanFactory::getBean`, which enables SpEL expression resolution and Spring-managed `ValueResolver` beans.
 

--- a/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/annotation/BaggageKeyValueAnnotationTests.java
+++ b/micrometer-tracing-tests/micrometer-tracing-test/src/test/java/io/micrometer/tracing/test/annotation/BaggageKeyValueAnnotationTests.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.test.annotation;
+
+import io.micrometer.common.annotation.ValueExpressionResolver;
+import io.micrometer.common.annotation.ValueResolver;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.annotation.*;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import org.assertj.core.api.BDDAssertions;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+class BaggageKeyValueAnnotationTests {
+
+    SimpleTracer tracer = new SimpleTracer();
+
+    TestBeanInterface testBean;
+
+    TestBeanInterface testBeanWithExpression;
+
+    @BeforeEach
+    void setup() {
+        // Using the no-arg BaggageKeyValueAnnotationHandler - resolver will be
+        // instantiated via reflection
+        BaggageKeyValueAnnotationHandler baggageHandler = new BaggageKeyValueAnnotationHandler();
+        ImperativeMethodInvocationProcessor processor = new ImperativeMethodInvocationProcessor(
+                new DefaultNewSpanParser(), tracer, null, baggageHandler);
+        AspectJProxyFactory pf = new AspectJProxyFactory(new TestBean(tracer));
+        pf.addAspect(new SpanAspect(processor));
+        testBean = pf.getProxy();
+
+        // Handler with expression resolver provider configured
+        ValueExpressionResolver expressionResolver = (expression, parameter) -> {
+            if ("toUpperCase".equals(expression) && parameter != null) {
+                return parameter.toString().toUpperCase();
+            }
+            return parameter != null ? parameter.toString() : "";
+        };
+        BaggageKeyValueAnnotationHandler baggageHandlerWithExpression = new BaggageKeyValueAnnotationHandler(
+                aClass -> null, aClass -> expressionResolver);
+        ImperativeMethodInvocationProcessor processorWithExpression = new ImperativeMethodInvocationProcessor(
+                new DefaultNewSpanParser(), tracer, null, baggageHandlerWithExpression);
+        AspectJProxyFactory pfExpr = new AspectJProxyFactory(new TestBean(tracer));
+        pfExpr.addAspect(new SpanAspect(processorWithExpression));
+        testBeanWithExpression = pfExpr.getProxy();
+    }
+
+    @Test
+    void shouldPutBaggageInScopeForMethodDuration() {
+        testBean.methodWithBaggage("myValue");
+
+        BDDAssertions.then(tracer.getSpans()).hasSize(1);
+        // Baggage should have been available during the method and closed after
+        BDDAssertions.then(tracer.getBaggage("myBaggage")).isNotNull();
+    }
+
+    @Test
+    void shouldPutBaggageInScopeAndCloseAfterMethod() {
+        AtomicReference<String> capturedValue = new AtomicReference<>();
+        testBean.methodWithBaggageCapture("capturedVal", capturedValue);
+
+        BDDAssertions.then(capturedValue.get()).isEqualTo("capturedVal");
+        BDDAssertions.then(tracer.getSpans()).hasSize(1);
+    }
+
+    @Test
+    void shouldPutBaggageInScopeWithDefaultName() {
+        AtomicReference<String> capturedValue = new AtomicReference<>();
+        testBean.methodWithDefaultBaggageName("defaultVal", capturedValue);
+
+        BDDAssertions.then(capturedValue.get()).isEqualTo("defaultVal");
+    }
+
+    @Test
+    void shouldPutMultipleBaggageEntriesInScope() {
+        AtomicReference<String> captured1 = new AtomicReference<>();
+        AtomicReference<String> captured2 = new AtomicReference<>();
+        testBean.methodWithMultipleBaggage("val1", "val2", captured1, captured2);
+
+        BDDAssertions.then(captured1.get()).isEqualTo("val1");
+        BDDAssertions.then(captured2.get()).isEqualTo("val2");
+    }
+
+    @Test
+    void shouldCloseBaggageScopeEvenOnException() {
+        try {
+            testBean.methodWithBaggageThrowsException("exVal");
+        }
+        catch (RuntimeException ignored) {
+        }
+
+        BDDAssertions.then(tracer.getSpans()).hasSize(1);
+    }
+
+    @Test
+    void shouldPutBaggageInScopeUsingKeyAttribute() {
+        AtomicReference<String> capturedValue = new AtomicReference<>();
+        testBean.methodWithBaggageKey("keyVal", capturedValue);
+
+        BDDAssertions.then(capturedValue.get()).isEqualTo("keyVal");
+        BDDAssertions.then(tracer.getSpans()).hasSize(1);
+    }
+
+    @Test
+    void shouldResolveBaggageValueUsingResolver() {
+        AtomicReference<String> capturedValue = new AtomicReference<>();
+        testBean.methodWithBaggageResolver("hello", capturedValue);
+
+        BDDAssertions.then(capturedValue.get()).isEqualTo("HELLO");
+        BDDAssertions.then(tracer.getSpans()).hasSize(1);
+    }
+
+    @Test
+    void shouldResolveBaggageValueUsingExpression() {
+        AtomicReference<String> capturedValue = new AtomicReference<>();
+        testBeanWithExpression.methodWithBaggageExpression("world", capturedValue);
+
+        BDDAssertions.then(capturedValue.get()).isEqualTo("WORLD");
+        BDDAssertions.then(tracer.getSpans()).hasSize(1);
+    }
+
+    @Test
+    void shouldThrowWhenExpressionUsedWithoutExpressionResolver() {
+        BDDAssertions.thenThrownBy(() -> testBean.methodWithBaggageExpression("value", new AtomicReference<>()))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("no ValueExpressionResolver is available");
+    }
+
+    @Test
+    void shouldPutBaggageInScopeWithContinueSpan() {
+        AtomicReference<String> capturedValue = new AtomicReference<>();
+        testBean.methodWithBaggageContinueSpan("continueVal", capturedValue);
+
+        BDDAssertions.then(capturedValue.get()).isEqualTo("continueVal");
+    }
+
+    @Test
+    void shouldHandleNullArgument() {
+        AtomicReference<String> capturedValue = new AtomicReference<>();
+        testBean.methodWithBaggageCapture(null, capturedValue);
+
+        // Null argument should result in empty string baggage value
+        BDDAssertions.then(capturedValue.get()).isEqualTo("");
+        BDDAssertions.then(tracer.getSpans()).hasSize(1);
+    }
+
+    protected interface TestBeanInterface {
+
+        void methodWithBaggage(@BaggageKeyValue("myBaggage") String value);
+
+        void methodWithBaggageCapture(@BaggageKeyValue("captured") @Nullable String value,
+                AtomicReference<String> capture);
+
+        void methodWithDefaultBaggageName(@BaggageKeyValue String value, AtomicReference<String> capture);
+
+        void methodWithMultipleBaggage(@BaggageKeyValue("baggage1") String val1,
+                @BaggageKeyValue("baggage2") String val2, AtomicReference<String> capture1,
+                AtomicReference<String> capture2);
+
+        void methodWithBaggageThrowsException(@BaggageKeyValue("exBaggage") String value);
+
+        void methodWithBaggageKey(@BaggageKeyValue(key = "keyBaggage") String value, AtomicReference<String> capture);
+
+        void methodWithBaggageResolver(
+                @BaggageKeyValue(value = "resolvedBaggage", resolver = UpperCaseResolver.class) String value,
+                AtomicReference<String> capture);
+
+        void methodWithBaggageExpression(
+                @BaggageKeyValue(value = "expressionBaggage", expression = "toUpperCase") String value,
+                AtomicReference<String> capture);
+
+        void methodWithBaggageContinueSpan(@BaggageKeyValue("continueBaggage") String value,
+                AtomicReference<String> capture);
+
+    }
+
+    protected static class TestBean implements TestBeanInterface {
+
+        private final Tracer tracer;
+
+        TestBean(Tracer tracer) {
+            this.tracer = tracer;
+        }
+
+        @NewSpan
+        @Override
+        public void methodWithBaggage(String value) {
+        }
+
+        @NewSpan
+        @Override
+        public void methodWithBaggageCapture(@Nullable String value, AtomicReference<String> capture) {
+            io.micrometer.tracing.Baggage baggage = tracer.getBaggage("captured");
+            if (baggage != null) {
+                capture.set(baggage.get());
+            }
+        }
+
+        @NewSpan
+        @Override
+        public void methodWithDefaultBaggageName(String value, AtomicReference<String> capture) {
+            // When no value is specified, the parameter name is used as baggage name.
+            // Due to compilation, parameter names may not be preserved,
+            // so we check all baggage entries.
+            var allBaggage = tracer.getAllBaggage();
+            if (!allBaggage.isEmpty()) {
+                capture.set(allBaggage.values().iterator().next());
+            }
+        }
+
+        @NewSpan
+        @Override
+        public void methodWithMultipleBaggage(String val1, String val2, AtomicReference<String> capture1,
+                AtomicReference<String> capture2) {
+            io.micrometer.tracing.Baggage b1 = tracer.getBaggage("baggage1");
+            io.micrometer.tracing.Baggage b2 = tracer.getBaggage("baggage2");
+            if (b1 != null) {
+                capture1.set(b1.get());
+            }
+            if (b2 != null) {
+                capture2.set(b2.get());
+            }
+        }
+
+        @NewSpan
+        @Override
+        public void methodWithBaggageThrowsException(String value) {
+            throw new RuntimeException("test exception");
+        }
+
+        @NewSpan
+        @Override
+        public void methodWithBaggageKey(String value, AtomicReference<String> capture) {
+            io.micrometer.tracing.Baggage baggage = tracer.getBaggage("keyBaggage");
+            if (baggage != null) {
+                capture.set(baggage.get());
+            }
+        }
+
+        @NewSpan
+        @Override
+        public void methodWithBaggageResolver(String value, AtomicReference<String> capture) {
+            io.micrometer.tracing.Baggage baggage = tracer.getBaggage("resolvedBaggage");
+            if (baggage != null) {
+                capture.set(baggage.get());
+            }
+        }
+
+        @NewSpan
+        @Override
+        public void methodWithBaggageExpression(String value, AtomicReference<String> capture) {
+            io.micrometer.tracing.Baggage baggage = tracer.getBaggage("expressionBaggage");
+            if (baggage != null) {
+                capture.set(baggage.get());
+            }
+        }
+
+        @ContinueSpan
+        @Override
+        public void methodWithBaggageContinueSpan(String value, AtomicReference<String> capture) {
+            var allBaggage = tracer.getAllBaggage();
+            if (!allBaggage.isEmpty()) {
+                capture.set(allBaggage.values().iterator().next());
+            }
+        }
+
+    }
+
+    /**
+     * A simple resolver that uppercases the argument value. Has a public no-arg
+     * constructor so it can be instantiated via reflection.
+     */
+    public static class UpperCaseResolver implements ValueResolver {
+
+        @Override
+        public String resolve(@Nullable Object parameter) {
+            return parameter != null ? parameter.toString().toUpperCase() : "";
+        }
+
+    }
+
+}

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/AbstractMethodInvocationProcessor.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/AbstractMethodInvocationProcessor.java
@@ -36,12 +36,21 @@ abstract class AbstractMethodInvocationProcessor implements MethodInvocationProc
 
     @Nullable SpanTagAnnotationHandler spanTagAnnotationHandler;
 
+    @Nullable BaggageKeyValueAnnotationHandler baggageKeyValueAnnotationHandler;
+
     AbstractMethodInvocationProcessor(NewSpanParser newSpanParser, Tracer tracer,
             CurrentTraceContext currentTraceContext, @Nullable SpanTagAnnotationHandler spanTagAnnotationHandler) {
+        this(newSpanParser, tracer, currentTraceContext, spanTagAnnotationHandler, null);
+    }
+
+    AbstractMethodInvocationProcessor(NewSpanParser newSpanParser, Tracer tracer,
+            CurrentTraceContext currentTraceContext, @Nullable SpanTagAnnotationHandler spanTagAnnotationHandler,
+            @Nullable BaggageKeyValueAnnotationHandler baggageKeyValueAnnotationHandler) {
         this.newSpanParser = newSpanParser;
         this.tracer = tracer;
         this.currentTraceContext = currentTraceContext;
         this.spanTagAnnotationHandler = spanTagAnnotationHandler;
+        this.baggageKeyValueAnnotationHandler = baggageKeyValueAnnotationHandler;
     }
 
     void before(MethodInvocation invocation, Span span, String log, boolean hasLog) {
@@ -110,6 +119,14 @@ abstract class AbstractMethodInvocationProcessor implements MethodInvocationProc
      */
     public void setSpanTagAnnotationHandler(SpanTagAnnotationHandler spanTagAnnotationHandler) {
         this.spanTagAnnotationHandler = spanTagAnnotationHandler;
+    }
+
+    /**
+     * Setting this enables support for {@link BaggageKeyValue}.
+     * @param baggageKeyValueAnnotationHandler baggage key value annotation handler
+     */
+    public void setBaggageKeyValueAnnotationHandler(BaggageKeyValueAnnotationHandler baggageKeyValueAnnotationHandler) {
+        this.baggageKeyValueAnnotationHandler = baggageKeyValueAnnotationHandler;
     }
 
 }

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/BaggageInScope.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/BaggageInScope.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.annotation;
+
+import io.micrometer.common.annotation.NoOpValueResolver;
+import io.micrometer.common.annotation.ValueResolver;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation to be used on method parameters to put the parameter value into baggage
+ * scope for the duration of the method execution. The baggage scope is automatically
+ * closed when the method completes.
+ * <p>
+ * There are 3 different ways to resolve the baggage value. All of them are controlled by
+ * the annotation values. Precedence is:
+ * <p>
+ * Try with the {@link ValueResolver} bean if the value of the bean wasn't set, try to
+ * evaluate a SPEL expression if there's no SPEL expression just return a
+ * {@code toString()} value of the parameter.
+ *
+ * @author Stuart Kemp
+ * @since 1.4.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Target(ElementType.PARAMETER)
+public @interface BaggageInScope {
+
+    /**
+     * The name of the baggage entry.
+     * @return the baggage name
+     */
+    String value() default "";
+
+    /**
+     * Execute this expression to calculate the baggage value. Will be analyzed if no
+     * value of the {@link BaggageInScope#resolver()} was set.
+     * @return an expression
+     */
+    String expression() default "";
+
+    /**
+     * Use this bean to resolve the baggage value. Has the highest precedence.
+     * @return {@link ValueResolver} bean
+     */
+    Class<? extends ValueResolver> resolver() default NoOpValueResolver.class;
+
+}

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/BaggageKeyValue.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/BaggageKeyValue.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.annotation;
+
+import io.micrometer.common.annotation.NoOpValueResolver;
+import io.micrometer.common.annotation.ValueResolver;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation to be used on method parameters to put the parameter value into baggage
+ * scope for the duration of the method execution. The baggage scope is automatically
+ * closed when the method completes.
+ * <p>
+ * There are 3 different ways to resolve the baggage value. All of them are controlled by
+ * the annotation values. Precedence is:
+ * <p>
+ * Try with the {@link ValueResolver} bean if the value of the bean wasn't set, try to
+ * evaluate a SPEL expression if there's no SPEL expression just return a
+ * {@code toString()} value of the parameter.
+ *
+ * @author Stuart Kemp
+ * @since 1.4.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Target(ElementType.PARAMETER)
+public @interface BaggageKeyValue {
+
+    /**
+     * The name of the baggage entry.
+     * @return the baggage name
+     */
+    String value() default "";
+
+    /**
+     * The name of the baggage entry. An alias for {@link #value()}.
+     * @return the baggage name
+     */
+    String key() default "";
+
+    /**
+     * Execute this expression to calculate the baggage value. Will be analyzed if no
+     * value of the {@link BaggageKeyValue#resolver()} was set.
+     * @return an expression
+     */
+    String expression() default "";
+
+    /**
+     * Use this bean to resolve the baggage value. Has the highest precedence.
+     * @return {@link ValueResolver} bean
+     */
+    Class<? extends ValueResolver> resolver() default NoOpValueResolver.class;
+
+}

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/BaggageKeyValueAnnotationHandler.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/BaggageKeyValueAnnotationHandler.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.annotation;
+
+import io.micrometer.common.annotation.NoOpValueResolver;
+import io.micrometer.common.annotation.ValueExpressionResolver;
+import io.micrometer.common.annotation.ValueResolver;
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import io.micrometer.tracing.Tracer;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Handler that processes {@link BaggageKeyValue} annotations on method parameters,
+ * opening baggage scopes that must be closed after method execution.
+ * <p>
+ * When a {@link BaggageKeyValue#resolver()} is specified, this handler first attempts to
+ * obtain the resolver from the configured provider (e.g. Spring bean lookup). If the
+ * provider returns {@code null} or is not configured, the handler falls back to
+ * instantiating the resolver class directly via its no-arg constructor.
+ *
+ * @author Stuart Kemp
+ * @since 1.4.0
+ */
+public class BaggageKeyValueAnnotationHandler {
+
+    private static final InternalLogger logger = InternalLoggerFactory
+        .getInstance(BaggageKeyValueAnnotationHandler.class);
+
+    private final Function<Class<? extends ValueResolver>, ? extends ValueResolver> resolverProvider;
+
+    private final Function<Class<? extends ValueExpressionResolver>, ? extends ValueExpressionResolver> expressionResolverProvider;
+
+    /**
+     * Creates a new handler with no external resolver providers. Resolvers specified via
+     * {@link BaggageKeyValue#resolver()} will be instantiated directly via their no-arg
+     * constructor.
+     */
+    public BaggageKeyValueAnnotationHandler() {
+        this(aClass -> new NoOpValueResolver(), aClass -> {
+            throw new UnsupportedOperationException("No ValueExpressionResolver configured");
+        });
+    }
+
+    public BaggageKeyValueAnnotationHandler(
+            Function<Class<? extends ValueResolver>, ? extends ValueResolver> resolverProvider,
+            Function<Class<? extends ValueExpressionResolver>, ? extends ValueExpressionResolver> expressionResolverProvider) {
+        this.resolverProvider = resolverProvider;
+        this.expressionResolverProvider = expressionResolverProvider;
+    }
+
+    /**
+     * Opens baggage scopes for all parameters annotated with {@link BaggageKeyValue}.
+     * @param tracer the tracer to use for creating baggage
+     * @param pjp the proceeding join point
+     * @return list of opened baggage scopes that must be closed
+     */
+    public List<io.micrometer.tracing.BaggageInScope> openBaggageScopes(Tracer tracer, ProceedingJoinPoint pjp) {
+        Method method = ((MethodSignature) pjp.getSignature()).getMethod();
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        Object[] args = pjp.getArgs();
+        if (parameterAnnotations.length == 0) {
+            return Collections.emptyList();
+        }
+        List<io.micrometer.tracing.BaggageInScope> scopes = new ArrayList<>();
+        for (int i = 0; i < parameterAnnotations.length; i++) {
+            for (Annotation annotation : parameterAnnotations[i]) {
+                if (annotation instanceof BaggageKeyValue) {
+                    BaggageKeyValue baggageAnnotation = (BaggageKeyValue) annotation;
+                    String name = resolveBaggageName(baggageAnnotation, method.getParameters()[i].getName());
+                    String value = resolveBaggageValue(baggageAnnotation, args[i]);
+                    scopes.add(tracer.createBaggageInScope(name, value));
+                }
+            }
+        }
+        return scopes;
+    }
+
+    private String resolveBaggageName(BaggageKeyValue annotation, String parameterName) {
+        if (StringUtils.isNotBlank(annotation.value())) {
+            return annotation.value();
+        }
+        if (StringUtils.isNotBlank(annotation.key())) {
+            return annotation.key();
+        }
+        return parameterName;
+    }
+
+    String resolveBaggageValue(BaggageKeyValue annotation, @Nullable Object argument) {
+        String value = null;
+        if (annotation.resolver() != NoOpValueResolver.class) {
+            ValueResolver resolver = getOrCreateResolver(annotation.resolver());
+            value = resolver.resolve(argument);
+        }
+        else if (StringUtils.isNotBlank(annotation.expression())) {
+            ValueExpressionResolver expressionResolver = getOrCreateExpressionResolver();
+            if (expressionResolver != null) {
+                value = expressionResolver.resolve(annotation.expression(), argument);
+            }
+            else {
+                throw new IllegalStateException("Expression [" + annotation.expression()
+                        + "] specified on @BaggageKeyValue but no ValueExpressionResolver is available. "
+                        + "If using Spring Boot, ensure tracing auto-configuration is active. "
+                        + "Otherwise, provide a ValueExpressionResolver via the BaggageKeyValueAnnotationHandler "
+                        + "constructor or use a ValueResolver instead.");
+            }
+        }
+        else if (argument != null) {
+            value = argument.toString();
+        }
+        return value == null ? "" : value;
+    }
+
+    private ValueResolver getOrCreateResolver(Class<? extends ValueResolver> resolverClass) {
+        ValueResolver resolver = resolverProvider.apply(resolverClass);
+        if (resolver != null && !(resolver instanceof NoOpValueResolver)) {
+            return resolver;
+        }
+        try {
+            return resolverClass.getDeclaredConstructor().newInstance();
+        }
+        catch (Exception ex) {
+            throw new IllegalStateException(
+                    "Could not instantiate ValueResolver [" + resolverClass.getName()
+                            + "]. Ensure it has a public no-arg constructor or provide it via a resolver provider.",
+                    ex);
+        }
+    }
+
+    @Nullable private ValueExpressionResolver getOrCreateExpressionResolver() {
+        try {
+            return expressionResolverProvider.apply(ValueExpressionResolver.class);
+        }
+        catch (Exception ex) {
+            logger.debug("Could not obtain ValueExpressionResolver from provider", ex);
+            return null;
+        }
+    }
+
+}

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/ImperativeMethodInvocationProcessor.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/ImperativeMethodInvocationProcessor.java
@@ -74,8 +74,8 @@ public class ImperativeMethodInvocationProcessor extends AbstractMethodInvocatio
     /**
      * Creates a new instance of {@link ImperativeMethodInvocationProcessor}. This
      * constructor allows the resolver providers to be shared with the
-     * {@link BaggageKeyValueAnnotationHandler} so that expression-based resolution
-     * (e.g. SpEL) works for {@link BaggageKeyValue} annotations.
+     * {@link BaggageKeyValueAnnotationHandler} so that expression-based resolution (e.g.
+     * SpEL) works for {@link BaggageKeyValue} annotations.
      * @param newSpanParser new span parser
      * @param tracer tracer
      * @param spanTagAnnotationHandler resolves tags to be added to the span from the

--- a/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/ImperativeMethodInvocationProcessor.java
+++ b/micrometer-tracing/src/main/java/io/micrometer/tracing/annotation/ImperativeMethodInvocationProcessor.java
@@ -23,6 +23,8 @@ import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
 import org.aopalliance.intercept.MethodInvocation;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -44,7 +46,8 @@ public class ImperativeMethodInvocationProcessor extends AbstractMethodInvocatio
     public ImperativeMethodInvocationProcessor(NewSpanParser newSpanParser, Tracer tracer,
             Function<Class<? extends ValueResolver>, ? extends ValueResolver> resolverProvider,
             Function<Class<? extends ValueExpressionResolver>, ? extends ValueExpressionResolver> expressionResolverProvider) {
-        this(newSpanParser, tracer, new SpanTagAnnotationHandler(resolverProvider, expressionResolverProvider));
+        this(newSpanParser, tracer, new SpanTagAnnotationHandler(resolverProvider, expressionResolverProvider),
+                new BaggageKeyValueAnnotationHandler(resolverProvider, expressionResolverProvider));
     }
 
     /**
@@ -53,7 +56,7 @@ public class ImperativeMethodInvocationProcessor extends AbstractMethodInvocatio
      * @param tracer tracer
      */
     public ImperativeMethodInvocationProcessor(NewSpanParser newSpanParser, Tracer tracer) {
-        this(newSpanParser, tracer, null);
+        this(newSpanParser, tracer, (SpanTagAnnotationHandler) null);
     }
 
     /**
@@ -65,7 +68,44 @@ public class ImperativeMethodInvocationProcessor extends AbstractMethodInvocatio
      */
     public ImperativeMethodInvocationProcessor(NewSpanParser newSpanParser, Tracer tracer,
             @Nullable SpanTagAnnotationHandler spanTagAnnotationHandler) {
-        super(newSpanParser, tracer, tracer.currentTraceContext(), spanTagAnnotationHandler);
+        this(newSpanParser, tracer, spanTagAnnotationHandler, new BaggageKeyValueAnnotationHandler());
+    }
+
+    /**
+     * Creates a new instance of {@link ImperativeMethodInvocationProcessor}. This
+     * constructor allows the resolver providers to be shared with the
+     * {@link BaggageKeyValueAnnotationHandler} so that expression-based resolution
+     * (e.g. SpEL) works for {@link BaggageKeyValue} annotations.
+     * @param newSpanParser new span parser
+     * @param tracer tracer
+     * @param spanTagAnnotationHandler resolves tags to be added to the span from the
+     * annotations
+     * @param resolverProvider converts a class into an instance of resolver provider
+     * @param expressionResolverProvider converts a class into an instance of expression
+     * resolver provider
+     */
+    public ImperativeMethodInvocationProcessor(NewSpanParser newSpanParser, Tracer tracer,
+            @Nullable SpanTagAnnotationHandler spanTagAnnotationHandler,
+            Function<Class<? extends ValueResolver>, ? extends ValueResolver> resolverProvider,
+            Function<Class<? extends ValueExpressionResolver>, ? extends ValueExpressionResolver> expressionResolverProvider) {
+        this(newSpanParser, tracer, spanTagAnnotationHandler,
+                new BaggageKeyValueAnnotationHandler(resolverProvider, expressionResolverProvider));
+    }
+
+    /**
+     * Creates a new instance of {@link ImperativeMethodInvocationProcessor}.
+     * @param newSpanParser new span parser
+     * @param tracer tracer
+     * @param spanTagAnnotationHandler resolves tags to be added to the span from the
+     * annotations
+     * @param baggageKeyValueAnnotationHandler resolves baggage to be put in scope from
+     * the annotations
+     */
+    public ImperativeMethodInvocationProcessor(NewSpanParser newSpanParser, Tracer tracer,
+            @Nullable SpanTagAnnotationHandler spanTagAnnotationHandler,
+            @Nullable BaggageKeyValueAnnotationHandler baggageKeyValueAnnotationHandler) {
+        super(newSpanParser, tracer, tracer.currentTraceContext(), spanTagAnnotationHandler,
+                baggageKeyValueAnnotationHandler);
     }
 
     @Override
@@ -89,8 +129,13 @@ public class ImperativeMethodInvocationProcessor extends AbstractMethodInvocatio
         assert span != null;
         String log = log(continueSpan);
         boolean hasLog = StringUtils.isNotBlank(log);
+        List<io.micrometer.tracing.BaggageInScope> baggageScopes = Collections.emptyList();
         try (Tracer.SpanInScope ignored = tracer.withSpan(span)) {
             before(invocation, span, log, hasLog);
+            if (baggageKeyValueAnnotationHandler != null && invocation instanceof SpanAspectMethodInvocation) {
+                baggageScopes = baggageKeyValueAnnotationHandler.openBaggageScopes(tracer,
+                        ((SpanAspectMethodInvocation) invocation).getPjp());
+            }
             return invocation.proceed();
         }
         catch (Exception ex) {
@@ -98,6 +143,9 @@ public class ImperativeMethodInvocationProcessor extends AbstractMethodInvocatio
             throw ex;
         }
         finally {
+            for (io.micrometer.tracing.BaggageInScope baggageScope : baggageScopes) {
+                baggageScope.close();
+            }
             after(span, startNewSpan, log, hasLog);
         }
     }


### PR DESCRIPTION
Addresses https://github.com/micrometer-metrics/tracing/issues/1270.

Introduce @BaggageKeyValue parameter annotation that puts method argument values into baggage scope for the duration of the method execution. Baggage scopes are automatically closed on method completion, including on exception.

The annotation supports three resolution strategies with the following precedence: ValueResolver, expression, and toString() fallback. The 'value' and 'key' attributes control the baggage entry name.

Add BaggageKeyValueAnnotationHandler to process annotations and manage baggage scope lifecycle. Add a 5-arg ImperativeMethodInvocationProcessor constructor that accepts resolver and expression resolver providers, allowing both @SpanTag and @BaggageKeyValue to share the same providers.