### PR TITLE
Remove Gradle Wrapper configuration block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -386,8 +386,4 @@ nexusPublishing {
 	}
 }
 
-wrapper {
-	gradleVersion = '9.3.0'
-}
-
 defaultTasks 'build'


### PR DESCRIPTION
This PR removes the Gradle Wrapper configuration block as it's not used by Dependabot.

See https://github.com/micrometer-metrics/tracing/pull/1413