### PR TITLE
docs: document EventPublishingContextWrapper required for OTel log correlation

### DIFF
--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -47,6 +47,18 @@ The following example shows how to create a Micrometer Tracing `Tracer` by using
 include::{include-java}/tracing/TracingApiTests.java[tags=otel_setup,indent=0]
 -----
 
+IMPORTANT: To enable log correlation (SLF4J MDC propagation of `traceId` and `spanId`), you must also register the `EventPublishingContextWrapper` with OTel's `ContextStorage` **once at application startup**.
+Without this step, `Slf4JEventListener` and `Slf4JBaggageEventListener` will not fire, and MDC will not contain trace/span IDs even though the `OtelTracer` is otherwise configured correctly.
+
+[source,java]
+-----
+// Call this once when your application starts (e.g., in a @Configuration class or main())
+ContextStorage.addWrapper(new EventPublishingContextWrapper(eventPublisher));
+-----
+
+NOTE: In a Spring Boot application with `micrometer-tracing-bridge-otel` on the classpath, this is handled automatically by autoconfiguration.
+You only need this manual step in non-Boot setups.
+
 == Micrometer Tracing Baggage API
 
 Traces connect from application to application by using header propagation. Besides trace identifiers, other properties (called `Baggage`) can also be passed along with the request.

--- a/docs/src/test/java/io/micrometer/docs/tracing/TracingApiTests.java
+++ b/docs/src/test/java/io/micrometer/docs/tracing/TracingApiTests.java
@@ -237,14 +237,20 @@ class TracingApiTests {
         // with correlation fields (currently we're setting empty list)
         Slf4JBaggageEventListener slf4JBaggageEventListener = new Slf4JBaggageEventListener(Collections.emptyList());
 
+        // [Micrometer Tracing component] The event publisher wires the Slf4J listeners
+        // to scope events (span start/end). Extracted as a named field so it can be
+        // reused when registering the EventPublishingContextWrapper (see below).
+        OtelTracer.EventPublisher eventPublisher = event -> {
+            slf4JEventListener.onEvent(event);
+            slf4JBaggageEventListener.onEvent(event);
+        };
+
         // [Micrometer Tracing component] A Micrometer Tracing wrapper for OTel's Tracer.
         // You can consider
         // customizing the baggage manager with correlation and remote fields (currently
         // we're setting empty lists)
-        OtelTracer tracer = new OtelTracer(otelTracer, otelCurrentTraceContext, event -> {
-            slf4JEventListener.onEvent(event);
-            slf4JBaggageEventListener.onEvent(event);
-        }, new OtelBaggageManager(otelCurrentTraceContext, Collections.emptyList(), Collections.emptyList()));
+        OtelTracer tracer = new OtelTracer(otelTracer, otelCurrentTraceContext, eventPublisher,
+                new OtelBaggageManager(otelCurrentTraceContext, Collections.emptyList(), Collections.emptyList()));
 
         // end::otel_setup[]
 


### PR DESCRIPTION
## Problem

The OTel setup documentation at `docs/modules/ROOT/pages/api.adoc` shows how to wire `Slf4JEventListener` and `Slf4JBaggageEventListener` into an `OtelTracer`, but it was missing a critical step: registering `EventPublishingContextWrapper` with OTel's `ContextStorage`.

Without this step, the listeners never receive scope-change events, so SLF4J MDC is never populated with `traceId`/`spanId`, breaking log correlation even though everything else looks correctly configured.

## Changes

### `docs/modules/ROOT/pages/api.adoc`
Add an `IMPORTANT` callout after the `otel_setup` code block:
- Shows the missing `ContextStorage.addWrapper(new EventPublishingContextWrapper(eventPublisher))` one-liner
- Adds a `NOTE` that Spring Boot's autoconfiguration handles this automatically, so the step is only needed for non-Boot setups

### `docs/src/test/java/.../TracingApiTests.java`
Extract the inline event publisher lambda into a named `eventPublisher` field so the docs snippet clearly shows what object to pass to `EventPublishingContextWrapper`.

Closes #1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)