### PR TITLE
Allow customizing OTel span status on error via a callback

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelScopedSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelScopedSpan.java
@@ -22,6 +22,8 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 
+import java.util.Objects;
+
 /**
  * OpenTelemetry implementation of a {@link ScopedSpan}.
  *
@@ -34,9 +36,16 @@ class OtelScopedSpan implements ScopedSpan {
 
     final Scope scope;
 
+    final SpanErrorStatusHandler errorStatusHandler;
+
     OtelScopedSpan(Span span, Scope scope) {
+        this(span, scope, SpanErrorStatusHandler.DEFAULT);
+    }
+
+    OtelScopedSpan(Span span, Scope scope, SpanErrorStatusHandler errorStatusHandler) {
         this.span = span;
         this.scope = scope;
+        this.errorStatusHandler = Objects.requireNonNull(errorStatusHandler, "errorStatusHandler must not be null");
     }
 
     @Override
@@ -70,7 +79,7 @@ class OtelScopedSpan implements ScopedSpan {
     @Override
     public ScopedSpan error(Throwable throwable) {
         this.span.recordException(throwable);
-        this.span.setStatus(StatusCode.ERROR, throwable.getMessage());
+        this.errorStatusHandler.handle(throwable, this.span);
         return this;
     }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java
@@ -42,19 +42,32 @@ public class OtelSpan implements Span {
 
     final OtelTraceContext otelTraceContext;
 
+    final SpanErrorStatusHandler errorStatusHandler;
+
     public OtelSpan(io.opentelemetry.api.trace.Span delegate) {
+        this(delegate, SpanErrorStatusHandler.DEFAULT);
+    }
+
+    public OtelSpan(io.opentelemetry.api.trace.Span delegate, SpanErrorStatusHandler errorStatusHandler) {
         this.delegate = delegate;
         this.otelTraceContext = new OtelTraceContext(delegate.getSpanContext(), delegate);
+        this.errorStatusHandler = Objects.requireNonNull(errorStatusHandler, "errorStatusHandler must not be null");
     }
 
     public OtelSpan(io.opentelemetry.api.trace.Span delegate, Context context) {
         this.delegate = delegate;
         this.otelTraceContext = new OtelTraceContext(context, delegate.getSpanContext(), delegate);
+        this.errorStatusHandler = SpanErrorStatusHandler.DEFAULT;
     }
 
     public OtelSpan(OtelTraceContext traceContext) {
+        this(traceContext, SpanErrorStatusHandler.DEFAULT);
+    }
+
+    public OtelSpan(OtelTraceContext traceContext, SpanErrorStatusHandler errorStatusHandler) {
         this.delegate = traceContext.span != null ? traceContext.span : io.opentelemetry.api.trace.Span.current();
         this.otelTraceContext = traceContext;
+        this.errorStatusHandler = Objects.requireNonNull(errorStatusHandler, "errorStatusHandler must not be null");
     }
 
     public static io.opentelemetry.api.trace.Span toOtel(Span span) {
@@ -63,6 +76,10 @@ public class OtelSpan implements Span {
 
     public static Span fromOtel(io.opentelemetry.api.trace.Span span) {
         return new OtelSpan(span);
+    }
+
+    public static Span fromOtel(io.opentelemetry.api.trace.Span span, SpanErrorStatusHandler errorStatusHandler) {
+        return new OtelSpan(span, errorStatusHandler);
     }
 
     public static Span fromOtel(io.opentelemetry.api.trace.Span span, Context context) {
@@ -169,12 +186,7 @@ public class OtelSpan implements Span {
     @Override
     public Span error(Throwable throwable) {
         this.delegate.recordException(throwable);
-        if (throwable.getMessage() == null) {
-            this.delegate.setStatus(StatusCode.ERROR);
-        }
-        else {
-            this.delegate.setStatus(StatusCode.ERROR, throwable.getMessage());
-        }
+        this.errorStatusHandler.handle(throwable, this.delegate);
         return this;
     }
 

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilder.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilder.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static io.micrometer.tracing.otel.bridge.OtelSpan.PEER_SERVICE;
@@ -45,6 +46,8 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 class OtelSpanBuilder implements Span.Builder {
 
     private final Tracer tracer;
+
+    private final SpanErrorStatusHandler errorStatusHandler;
 
     private final List<String> annotations = new LinkedList<>();
 
@@ -67,7 +70,12 @@ class OtelSpanBuilder implements Span.Builder {
     private List<Map.Entry<SpanContext, Attributes>> links = new ArrayList<>();
 
     OtelSpanBuilder(Tracer tracer) {
+        this(tracer, SpanErrorStatusHandler.DEFAULT);
+    }
+
+    OtelSpanBuilder(Tracer tracer, SpanErrorStatusHandler errorStatusHandler) {
         this.tracer = tracer;
+        this.errorStatusHandler = Objects.requireNonNull(errorStatusHandler, "errorStatusHandler must not be null");
     }
 
     static Span.Builder fromOtel(Tracer tracer) {
@@ -242,14 +250,15 @@ class OtelSpanBuilder implements Span.Builder {
         io.opentelemetry.api.trace.Span span = spanBuilder.startSpan();
         if (this.error != null) {
             span.recordException(this.error);
-            span.setStatus(StatusCode.ERROR, this.error.getMessage());
+            this.errorStatusHandler.handle(this.error, span);
         }
         this.annotations.forEach(span::addEvent);
         if (this.parentTraceContext != null) {
             return OtelSpan.fromOtel(
-                    new SpanFromSpanContext(span, span.getSpanContext(), (OtelTraceContext) this.parentTraceContext));
+                    new SpanFromSpanContext(span, span.getSpanContext(), (OtelTraceContext) this.parentTraceContext),
+                    this.errorStatusHandler);
         }
-        return OtelSpan.fromOtel(span);
+        return OtelSpan.fromOtel(span, this.errorStatusHandler);
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelTracer.java
@@ -22,6 +22,7 @@ import io.opentelemetry.context.Scope;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * OpenTelemetry implementation of a {@link Tracer}.
@@ -39,6 +40,8 @@ public class OtelTracer implements Tracer {
 
     private final EventPublisher publisher;
 
+    private final SpanErrorStatusHandler errorStatusHandler;
+
     /**
      * Creates a new instance of {@link OtelTracer}.
      * @param tracer tracer
@@ -48,10 +51,26 @@ public class OtelTracer implements Tracer {
      */
     public OtelTracer(io.opentelemetry.api.trace.Tracer tracer, OtelCurrentTraceContext otelCurrentTraceContext,
             EventPublisher publisher, BaggageManager otelBaggageManager) {
+        this(tracer, otelCurrentTraceContext, publisher, otelBaggageManager, SpanErrorStatusHandler.DEFAULT);
+    }
+
+    /**
+     * Creates a new instance of {@link OtelTracer}.
+     * @param tracer tracer
+     * @param otelCurrentTraceContext current trace context
+     * @param publisher event publisher
+     * @param otelBaggageManager baggage manager
+     * @param errorStatusHandler handler determining the span status when an error is
+     * reported
+     * @since 1.8.0
+     */
+    public OtelTracer(io.opentelemetry.api.trace.Tracer tracer, OtelCurrentTraceContext otelCurrentTraceContext,
+            EventPublisher publisher, BaggageManager otelBaggageManager, SpanErrorStatusHandler errorStatusHandler) {
         this.tracer = tracer;
         this.publisher = publisher;
         this.otelBaggageManager = otelBaggageManager;
         this.otelCurrentTraceContext = otelCurrentTraceContext;
+        this.errorStatusHandler = Objects.requireNonNull(errorStatusHandler, "errorStatusHandler must not be null");
     }
 
     /**
@@ -79,9 +98,9 @@ public class OtelTracer implements Tracer {
             scope = otelContext.makeCurrent();
         }
         try {
-            return OtelSpan.fromOtel(this.tracer.spanBuilder("")
-                .setParent(OtelTraceContext.toOtelContext(parent.context()))
-                .startSpan());
+            return OtelSpan.fromOtel(
+                    this.tracer.spanBuilder("").setParent(OtelTraceContext.toOtelContext(parent.context())).startSpan(),
+                    this.errorStatusHandler);
         }
         finally {
             if (scope != null) {
@@ -122,30 +141,30 @@ public class OtelTracer implements Tracer {
             if (io.opentelemetry.api.trace.Span.getInvalid().equals(context.span)) {
                 return null;
             }
-            return new OtelSpan(context);
+            return new OtelSpan(context, this.errorStatusHandler);
         }
         io.opentelemetry.api.trace.Span currentSpan = io.opentelemetry.api.trace.Span.current();
         if (currentSpan == null || currentSpan.equals(io.opentelemetry.api.trace.Span.getInvalid())) {
             return null;
         }
-        return new OtelSpan(currentSpan);
+        return new OtelSpan(currentSpan, this.errorStatusHandler);
     }
 
     @Override
     public Span nextSpan() {
-        return new OtelSpan(this.tracer.spanBuilder("").startSpan());
+        return new OtelSpan(this.tracer.spanBuilder("").startSpan(), this.errorStatusHandler);
     }
 
     @Override
     @SuppressWarnings("MustBeClosedChecker")
     public ScopedSpan startScopedSpan(String name) {
         io.opentelemetry.api.trace.Span span = this.tracer.spanBuilder(name).startSpan();
-        return new OtelScopedSpan(span, span.makeCurrent());
+        return new OtelScopedSpan(span, span.makeCurrent(), this.errorStatusHandler);
     }
 
     @Override
     public Span.Builder spanBuilder() {
-        return new OtelSpanBuilder(this.tracer);
+        return new OtelSpanBuilder(this.tracer, this.errorStatusHandler);
     }
 
     @Override

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/SpanErrorStatusHandler.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/SpanErrorStatusHandler.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.otel.bridge;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+
+/**
+ * Decides the {@link StatusCode status} to set on an OpenTelemetry {@link Span} when an
+ * error is reported via {@link io.micrometer.tracing.Span#error(Throwable)},
+ * {@link io.micrometer.tracing.ScopedSpan#error(Throwable)} or
+ * {@link io.micrometer.tracing.Span.Builder#error(Throwable)}. The exception is always
+ * recorded on the span (via {@link Span#recordException(Throwable)}) before this handler
+ * runs; this handler is responsible only for the status.
+ * <p>
+ * The {@link #DEFAULT default} implementation always sets the status to
+ * {@link StatusCode#ERROR}. A custom implementation may, for example, leave the status
+ * unset for exceptions that are considered expected, in which case the span will be
+ * marked {@link StatusCode#OK} when it ends.
+ *
+ * @since 1.8.0
+ */
+@FunctionalInterface
+public interface SpanErrorStatusHandler {
+
+    /**
+     * Default handler reproducing the historical behavior: always set the status to
+     * {@link StatusCode#ERROR}, using the throwable's message as the description when
+     * present.
+     */
+    SpanErrorStatusHandler DEFAULT = (error, span) -> {
+        if (error.getMessage() == null) {
+            span.setStatus(StatusCode.ERROR);
+        }
+        else {
+            span.setStatus(StatusCode.ERROR, error.getMessage());
+        }
+    };
+
+    /**
+     * Sets the status on the given span based on the given error.
+     * @param error the error that was reported
+     * @param span the OpenTelemetry span whose status should be set
+     */
+    void handle(Throwable error, Span span);
+
+}

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/SpanErrorStatusHandlerTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/SpanErrorStatusHandlerTests.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.otel.bridge;
+
+import io.micrometer.tracing.ScopedSpan;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SpanErrorStatusHandlerTests {
+
+    InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+
+    SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+        .setSampler(Sampler.alwaysOn())
+        .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+        .build();
+
+    OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder().setTracerProvider(sdkTracerProvider).build();
+
+    io.opentelemetry.api.trace.Tracer otelTracer = openTelemetrySdk.getTracer("io.micrometer.micrometer-tracing");
+
+    OtelCurrentTraceContext otelCurrentTraceContext = new OtelCurrentTraceContext();
+
+    /**
+     * Treats {@link ExpectedException} as expected (leaves the status unset, so the span
+     * ends as OK) and prefixes the description for every other error.
+     */
+    SpanErrorStatusHandler customHandler = (error, span) -> {
+        if (error instanceof ExpectedException) {
+            return;
+        }
+        span.setStatus(StatusCode.ERROR, "custom: " + error.getMessage());
+    };
+
+    OtelTracer defaultTracer = new OtelTracer(otelTracer, otelCurrentTraceContext, event -> {
+    });
+
+    OtelTracer customTracer = new OtelTracer(otelTracer, otelCurrentTraceContext, event -> {
+    }, new OtelBaggageManager(otelCurrentTraceContext, Collections.emptyList(), Collections.emptyList()),
+            customHandler);
+
+    @Test
+    void default_handler_sets_error_status() {
+        defaultTracer.nextSpan().name("foo").start().error(new RuntimeException("boom")).end();
+
+        SpanData spanData = onlyFinishedSpan();
+        assertThat(spanData.getStatus()).isEqualTo(StatusData.create(StatusCode.ERROR, "boom"));
+        assertThat(spanData.getEvents()).extracting(e -> e.getName()).containsExactly("exception");
+    }
+
+    @Test
+    void custom_handler_leaves_status_unset_for_expected_exception_on_span() {
+        customTracer.nextSpan().name("foo").start().error(new ExpectedException("ignored")).end();
+
+        SpanData spanData = onlyFinishedSpan();
+        // status left unset by the handler -> OK on end
+        assertThat(spanData.getStatus().getStatusCode()).isEqualTo(StatusCode.OK);
+        // exception is still recorded regardless of the status decision
+        assertThat(spanData.getEvents()).extracting(e -> e.getName()).containsExactly("exception");
+    }
+
+    @Test
+    void custom_handler_leaves_status_unset_for_expected_exception_on_scoped_span() {
+        ScopedSpan scopedSpan = customTracer.startScopedSpan("foo");
+        scopedSpan.error(new ExpectedException("ignored"));
+        scopedSpan.end();
+
+        SpanData spanData = onlyFinishedSpan();
+        assertThat(spanData.getStatus().getStatusCode()).isEqualTo(StatusCode.OK);
+        assertThat(spanData.getEvents()).extracting(e -> e.getName()).containsExactly("exception");
+    }
+
+    @Test
+    void custom_handler_leaves_status_unset_for_expected_exception_on_builder() {
+        customTracer.spanBuilder().name("foo").error(new ExpectedException("ignored")).start().end();
+
+        SpanData spanData = onlyFinishedSpan();
+        assertThat(spanData.getStatus().getStatusCode()).isEqualTo(StatusCode.OK);
+        assertThat(spanData.getEvents()).extracting(e -> e.getName()).containsExactly("exception");
+    }
+
+    @Test
+    void custom_handler_can_set_custom_description() {
+        customTracer.nextSpan().name("foo").start().error(new RuntimeException("boom")).end();
+
+        SpanData spanData = onlyFinishedSpan();
+        assertThat(spanData.getStatus()).isEqualTo(StatusData.create(StatusCode.ERROR, "custom: boom"));
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void null_handler_is_rejected() {
+        assertThatThrownBy(() -> new OtelTracer(otelTracer, otelCurrentTraceContext, event -> {
+        }, new OtelBaggageManager(otelCurrentTraceContext, Collections.emptyList(), Collections.emptyList()), null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("errorStatusHandler");
+    }
+
+    private SpanData onlyFinishedSpan() {
+        assertThat(spanExporter.getFinishedSpanItems()).hasSize(1);
+        return spanExporter.getFinishedSpanItems().get(0);
+    }
+
+    static class ExpectedException extends RuntimeException {
+
+        ExpectedException(String message) {
+            super(message);
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Problem

In the OpenTelemetry bridge, reporting an error on a span **always** sets the delegate span's status to `ERROR`. This happens in three places:

- [`OtelSpan.error(Throwable)`](https://github.com/micrometer-metrics/tracing/blob/ad3eff40f6edda40c96c2295e0abdefd327c1bea/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpan.java#L172-L177)
- [`OtelScopedSpan.error(Throwable)`](https://github.com/micrometer-metrics/tracing/blob/ad3eff40f6edda40c96c2295e0abdefd327c1bea/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelScopedSpan.java#L73)
- [`OtelSpanBuilder.start()`](https://github.com/micrometer-metrics/tracing/blob/ad3eff40f6edda40c96c2295e0abdefd327c1bea/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilder.java#L245) (when an error was set on the builder)

There is no hook to influence this. In practice, some exceptions are *expected* (e.g. a `NotFoundException` that maps to a `404`) and I'd like for these to not cause the span to be marked as errored.

## Change

Introduce `SpanErrorStatusHandler`, a `@FunctionalInterface` that decides the status to set on the OTel span for a given throwable:

```java
@FunctionalInterface
public interface SpanErrorStatusHandler {

	SpanErrorStatusHandler DEFAULT = (error, span) -> {
		if (error.getMessage() == null) {
			span.setStatus(StatusCode.ERROR);
		}
		else {
			span.setStatus(StatusCode.ERROR, error.getMessage());
		}
	};

	void handle(Throwable error, io.opentelemetry.api.trace.Span span);
}
```

The `DEFAULT` implementation is the same as the behavior prior to this change.

The exception is still always recorded via `Span.recordException(...)`; the handler is responsible **only** for the status. Leaving the status unset means the span is marked `OK` on end, which is how a handler treats an exception as expected.

The handler is configured on `OtelTracer` through a new constructor overload and threaded into every span the tracer creates (`nextSpan`, `currentSpan`, `startScopedSpan`, `spanBuilder`).  For example, using a custom handler would look something like this:

```java
OtelTracer tracer = new OtelTracer(otelTracer, currentTraceContext, publisher,
		baggageManager, (error, span) -> {
	if (error instanceof ExpectedException) {
		return; // leave status unset -> span ends OK
	}
	span.setStatus(StatusCode.ERROR, error.getMessage());
});
```

## Backward compatibility

Fully backward compatible. `OtelSpan`, `OtelScopedSpan` and `OtelSpanBuilder` now carry the handler via new constructor/factory variants, but **all existing constructors and factories default to `SpanErrorStatusHandler.DEFAULT`**, which reproduces today's behavior exactly. No public API is removed or changed.

Routing all three call sites through the default also unifies a small existing inconsistency: `OtelScopedSpan` and `OtelSpanBuilder` previously passed a possibly-null message straight to `setStatus(ERROR, message)`, while `OtelSpan` null-checked it. Both are equivalent in the OTel SDK, so this is a harmless consolidation.

## Tests

Added `SpanErrorStatusHandlerTests` covering:

- Default behavior unchanged: status `ERROR` with the throwable message, and the exception event still recorded.
- A custom "expected exception" handler that leaves the status unset, asserting the span ends `OK` while the exception event is still recorded, verified across `Span.error`, `ScopedSpan.error` and `Span.Builder.error`.
- A custom handler setting a different status description.

## Out of scope

- The generic `Span.Builder` API in `micrometer-tracing-api` is untouched; this is OTel-specific configuration only (no per-builder override).
- The Brave bridge is untouched; it delegates status handling to Brave and does not set OTel status codes.
- Downstream wiring (e.g. Spring Boot auto-configuration) is not part of this change; consumers can opt in by using the new `OtelTracer` constructor.  Assuming this PR is merged, I might submit a follow-up Spring Boot PR to allow a custom `SpanErrorStatusHandler` to be auto-configured if a bean of that type is found.