### PR TITLE
Log4j2 TraceContextProvider SPI integration

### DIFF
--- a/micrometer-tracing-log4j2/build.gradle
+++ b/micrometer-tracing-log4j2/build.gradle
@@ -7,8 +7,9 @@ repositories {
 dependencies {
     api project(':micrometer-tracing')
 
-    compileOnly 'org.apache.logging.log4j:log4j-api'
-    testImplementation 'org.apache.logging.log4j:log4j-core'
+    // Compile against the latest Log4j API (which has your new SPI)
+    compileOnly 'org.apache.logging.log4j:log4j-api:2.27.0-SNAPSHOT'
+    testImplementation 'org.apache.logging.log4j:log4j-core:2.27.0-SNAPSHOT'
     testImplementation(libs.junitJupiter)
     testImplementation(libs.assertj)
     testImplementation(libs.mockitoCore)

--- a/micrometer-tracing-log4j2/build.gradle
+++ b/micrometer-tracing-log4j2/build.gradle
@@ -1,0 +1,17 @@
+description = 'Micrometer Tracing Log4j 2 Integration'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+dependencies {
+    api project(':micrometer-tracing')
+
+    // Compile against the latest Log4j API (which has your new SPI)
+    compileOnly 'org.apache.logging.log4j:log4j-api:2.27.0-SNAPSHOT'
+
+    testImplementation 'org.apache.logging.log4j:log4j-core:2.27.0-SNAPSHOT'
+    testImplementation(libs.junitJupiter)
+    testImplementation(libs.assertj)
+    testImplementation(libs.mockitoCore)
+}

--- a/micrometer-tracing-log4j2/build.gradle
+++ b/micrometer-tracing-log4j2/build.gradle
@@ -7,10 +7,8 @@ repositories {
 dependencies {
     api project(':micrometer-tracing')
 
-    // Compile against the latest Log4j API (which has your new SPI)
-    compileOnly 'org.apache.logging.log4j:log4j-api:2.27.0-SNAPSHOT'
-
-    testImplementation 'org.apache.logging.log4j:log4j-core:2.27.0-SNAPSHOT'
+    compileOnly 'org.apache.logging.log4j:log4j-api'
+    testImplementation 'org.apache.logging.log4j:log4j-core'
     testImplementation(libs.junitJupiter)
     testImplementation(libs.assertj)
     testImplementation(libs.mockitoCore)

--- a/micrometer-tracing-log4j2/src/main/java/io/micrometer/tracing/log4j2/MicrometerTraceContextProvider.java
+++ b/micrometer-tracing-log4j2/src/main/java/io/micrometer/tracing/log4j2/MicrometerTraceContextProvider.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2026 VMware, Inc.
+/**
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-tracing-log4j2/src/main/java/io/micrometer/tracing/log4j2/MicrometerTraceContextProvider.java
+++ b/micrometer-tracing-log4j2/src/main/java/io/micrometer/tracing/log4j2/MicrometerTraceContextProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.log4j2;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import org.apache.logging.log4j.spi.TraceContextProvider;
+
+/**
+ * A Log4j 2 {@link TraceContextProvider} that extracts tracing metadata from the
+ * Micrometer {@link Tracer}.
+ * <p>
+ * Because Log4j 2 instantiates this via the {@link java.util.ServiceLoader} mechanism
+ * (which requires a no-arg constructor), the active {@link Tracer} must be supplied
+ * statically during application startup (e.g., via Spring Boot Auto-Configuration).
+ */
+public class MicrometerTraceContextProvider implements TraceContextProvider {
+
+    private static volatile Tracer tracer;
+
+    /**
+     * Sets the active Micrometer Tracer to be used by Log4j 2.
+     *
+     * @param activeTracer the tracer instance
+     */
+    public static void setTracer(Tracer activeTracer) {
+        tracer = activeTracer;
+    }
+
+    @Override
+    public String getTraceId() {
+        if (tracer == null) {
+            return null;
+        }
+        Span currentSpan = tracer.currentSpan();
+        return (currentSpan != null && currentSpan.context() != null) ? currentSpan.context().traceId() : null;
+    }
+
+    @Override
+    public String getSpanId() {
+        if (tracer == null) {
+            return null;
+        }
+        Span currentSpan = tracer.currentSpan();
+        return (currentSpan != null && currentSpan.context() != null) ? currentSpan.context().spanId() : null;
+    }
+
+    @Override
+    public String getTraceFlags() {
+        // Micrometer's TraceContext does not natively expose W3C trace flags as a direct string.
+        // We safely return null, allowing Log4j to default to empty string.
+        return null;
+    }
+}

--- a/micrometer-tracing-log4j2/src/main/resources/META-INF/services/org.apache.logging.log4j.spi.TraceContextProvider
+++ b/micrometer-tracing-log4j2/src/main/resources/META-INF/services/org.apache.logging.log4j.spi.TraceContextProvider
@@ -1,0 +1,1 @@
+io.micrometer.tracing.log4j2.MicrometerTraceContextProvider

--- a/micrometer-tracing-log4j2/src/test/java/io/micrometer/tracing/log4j2/MicrometerTraceContextProviderTest.java
+++ b/micrometer-tracing-log4j2/src/test/java/io/micrometer/tracing/log4j2/MicrometerTraceContextProviderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.tracing.log4j2;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class MicrometerTraceContextProviderTest {
+
+    private final MicrometerTraceContextProvider provider = new MicrometerTraceContextProvider();
+
+    @AfterEach
+    void tearDown() {
+        // Clean up the static tracer after each test
+        MicrometerTraceContextProvider.setTracer(null);
+    }
+
+    @Test
+    void should_return_null_when_tracer_is_not_set() {
+        assertThat(provider.getTraceId()).isNull();
+        assertThat(provider.getSpanId()).isNull();
+        assertThat(provider.getTraceFlags()).isNull();
+    }
+
+    @Test
+    void should_return_null_when_no_active_span() {
+        Tracer tracer = mock(Tracer.class);
+        given(tracer.currentSpan()).willReturn(null);
+
+        MicrometerTraceContextProvider.setTracer(tracer);
+
+        assertThat(provider.getTraceId()).isNull();
+        assertThat(provider.getSpanId()).isNull();
+        assertThat(provider.getTraceFlags()).isNull();
+    }
+
+    @Test
+    void should_return_trace_and_span_ids_from_active_span() {
+        TraceContext context = mock(TraceContext.class);
+        given(context.traceId()).willReturn("4bf92f3577b34da6a3ce929d0e0e4736");
+        given(context.spanId()).willReturn("00f067aa0ba902b7");
+
+        Span span = mock(Span.class);
+        given(span.context()).willReturn(context);
+
+        Tracer tracer = mock(Tracer.class);
+        given(tracer.currentSpan()).willReturn(span);
+
+        MicrometerTraceContextProvider.setTracer(tracer);
+
+        assertThat(provider.getTraceId()).isEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
+        assertThat(provider.getSpanId()).isEqualTo("00f067aa0ba902b7");
+        assertThat(provider.getTraceFlags()).isNull(); // Micrometer does not expose native W3C flags directly
+    }
+}

--- a/micrometer-tracing-log4j2/src/test/java/io/micrometer/tracing/log4j2/MicrometerTraceContextProviderTest.java
+++ b/micrometer-tracing-log4j2/src/test/java/io/micrometer/tracing/log4j2/MicrometerTraceContextProviderTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2026 VMware, Inc.
+/**
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ class MicrometerTraceContextProviderTest {
 
     @AfterEach
     void tearDown() {
-        // Clean up the static tracer after each test
         MicrometerTraceContextProvider.setTracer(null);
     }
 
@@ -70,6 +69,6 @@ class MicrometerTraceContextProviderTest {
 
         assertThat(provider.getTraceId()).isEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
         assertThat(provider.getSpanId()).isEqualTo("00f067aa0ba902b7");
-        assertThat(provider.getTraceFlags()).isNull(); // Micrometer does not expose native W3C flags directly
+        assertThat(provider.getTraceFlags()).isNull();
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,7 +22,7 @@ buildCache {
 	}
 }
 
-include 'micrometer-tracing', 'micrometer-tracing-bom', 'benchmarks'
+include 'micrometer-tracing', 'micrometer-tracing-bom', 'benchmarks', 'micrometer-tracing-log4j2'
 
 ['brave', 'otel'].each { bridge ->
 	include "micrometer-tracing-bridge-$bridge"


### PR DESCRIPTION
Fix #1482

This Draft PR provides a lightweight `TraceContextProvider` implementation for the new zero-allocation Async Logging SPI being introduced in Apache Log4j 2.27.0 (via [apache/logging-log4j2#4171](https://github.com/apache/logging-log4j2/pull/4171)).

Because Log4j creates SPI instances via `ServiceLoader` using a no-arg constructor on startup, I've exposed a `public static void setTracer(Tracer)` method. Spring Boot auto-configuration can call this during startup to supply the active tracer.

**Note to Reviewers:** 
I set this as a Draft because the `log4j-api` version `2.27.0` is currently pending official release. I hardcoded `2.27.0-SNAPSHOT` locally to compile this via `mavenLocal()`. Once Log4j 2.27.0 is officially released to Maven Central, we can update the dependencies (likely adding it to `libs.versions.toml`) and merge this.

Let me know if you would prefer this class to live in a different module or if you'd prefer a different static bridging pattern!