### PR TITLE
Pin discontinued OpenTelemetry Zipkin exporter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,8 @@ mockitoCore = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockitoJunit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 nullAway = { module = "com.uber.nullaway:nullaway", version = "0.14.0" }
 otelInstrumentationBom = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom", version.ref = "otelInstrumentationBom" }
+# OpenTelemetry stopped publishing this exporter after 1.64.0.
+otelZipkinExporter = { module = "io.opentelemetry:opentelemetry-exporter-zipkin", version = "1.64.0" }
 reactorBom = { module = "io.projectreactor:reactor-bom", version.ref = "reactorBom" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 springCore = { module = "org.springframework:spring-core", version.ref = "spring" }

--- a/micrometer-tracing-tests/micrometer-tracing-integration-test/build.gradle
+++ b/micrometer-tracing-tests/micrometer-tracing-integration-test/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 	// OTel
 	api project(':micrometer-tracing-bridge-otel')
-	api 'io.opentelemetry:opentelemetry-exporter-zipkin'
+	api libs.otelZipkinExporter
 	api 'io.opentelemetry:opentelemetry-sdk-trace'
 	api 'io.opentelemetry:opentelemetry-extension-trace-propagators'
 	api 'io.opentelemetry:opentelemetry-sdk-testing'


### PR DESCRIPTION
Companion fix for #1533.

OpenTelemetry Java 1.65.0 stopped publishing `opentelemetry-exporter-zipkin`, but the instrumentation BOM 2.31.1 now imports the 1.65.0 core BOM. That leaves Micrometer's existing Zipkin integration with an unversioned dependency and makes every build fail during dependency resolution.

This keeps the instrumentation upgrade and pins only the discontinued Zipkin exporter to its final published version, 1.64.0. The remaining OpenTelemetry modules still resolve at 1.65.0. This preserves the existing `ZipkinOtelSetup` API and behavior rather than removing the integration. See the [OpenTelemetry Java 1.65.0 release note](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.65.0).

Verification:

- exact parent `d2bed99d2ca330b294e93a22b8678c94f52580d2`: `./gradlew downloadDependencies --no-daemon` passes
- exact Dependabot head `aed8d3d4a89039ddc8516f8185dc93a13ae2c8b9`: the same command fails because `opentelemetry-exporter-zipkin` has no version
- candidate: the same dependency-resolution command passes
- identical parent/candidate behavior check passes: `ZipkinOtelSetupTests` sends and verifies the real `/api/v2/spans` request through WireMock
- `./gradlew clean check --no-daemon`: 101 tasks, 768 tests, 0 failures/errors (22 skipped)
- CI-equivalent `./gradlew build` passes with toolchains 11, 17, 21, and 25: 115 tasks each
- `./gradlew dockerTest --no-daemon`: 41 tasks pass

Signed-off-by: Suraj Rajan <surajkrajan95@gmail.com>
