### PR TITLE
Remove Brave Zipkin dependency warning from reporters docs #509

### DIFF
--- a/docs/modules/ROOT/pages/reporters.adoc
+++ b/docs/modules/ROOT/pages/reporters.adoc
@@ -73,4 +73,3 @@ The following example shows the required dependency in Maven (assuming that Micr
 </dependency>
 ----
 
-IMPORTANT: Remember that, by default, Brave adds Zipkin as a dependency. If you want to use only Wavefront and you use classpath dependent solutions, such as Spring Boot, you might be required to exclude the transitive dependency on Zipkin when using Brave (for example, by excluding the `io.zipkin.reporter2` group).


### PR DESCRIPTION
Brave 6 no longer brings Zipkin in transitively. I dropped the Wavefront exclusion note from the reporters page.

Fixes #509