### PR TITLE
Start spans with the baggage stored in the parent trace context

### DIFF
--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilder.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/main/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilder.java
@@ -19,10 +19,13 @@ import io.micrometer.common.util.StringUtils;
 import io.micrometer.tracing.Link;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageBuilder;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.*;
+import io.opentelemetry.context.Context;
 import org.jspecify.annotations.Nullable;
 
 import java.util.AbstractMap.SimpleEntry;
@@ -228,7 +231,7 @@ class OtelSpanBuilder implements Span.Builder {
     public Span start() {
         SpanBuilder spanBuilder = this.tracer.spanBuilder(StringUtils.isNotEmpty(this.name) ? this.name : "");
         if (this.parentTraceContext != null) {
-            spanBuilder.setParent(OtelTraceContext.toOtelContext(this.parentTraceContext));
+            spanBuilder.setParent(parentContext(this.parentTraceContext));
         }
         if (this.noParent) {
             spanBuilder.setNoParent();
@@ -250,6 +253,31 @@ class OtelSpanBuilder implements Span.Builder {
                     new SpanFromSpanContext(span, span.getSpanContext(), (OtelTraceContext) this.parentTraceContext));
         }
         return OtelSpan.fromOtel(span);
+    }
+
+    /**
+     * Builds the OTel parent {@link Context} for the span that is about to start. Baggage
+     * that is stored in the parent {@link OtelTraceContext} (for example because it was
+     * extracted from a carrier by the {@link OtelPropagator}) but is not yet current on
+     * the thread is added to the parent context, so that it is visible to the SDK (e.g.
+     * {@link BaggageTaggingSpanProcessor} or samplers) when the span starts. Entries
+     * stored in the trace context take precedence over the current baggage, consistent
+     * with {@link OtelCurrentTraceContext#newScope(TraceContext)}.
+     * @param parentTraceContext parent trace context
+     * @return parent context to start the span with
+     */
+    private static Context parentContext(TraceContext parentTraceContext) {
+        Context parent = OtelTraceContext.toOtelContext(parentTraceContext);
+        if (!(parentTraceContext instanceof OtelTraceContext)) {
+            return parent;
+        }
+        Baggage stored = Baggage.fromContext(((OtelTraceContext) parentTraceContext).context());
+        if (stored.isEmpty()) {
+            return parent;
+        }
+        BaggageBuilder merged = Baggage.fromContext(parent).toBuilder();
+        stored.forEach((key, entry) -> merged.put(key, entry.getValue(), entry.getMetadata()));
+        return parent.with(merged.build());
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelPropagatorTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelPropagatorTests.java
@@ -23,7 +23,11 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -130,6 +134,27 @@ class OtelPropagatorTests {
                 .returns("3e425f2373d89640bde06e8285e7bf88", TraceContext::traceId)
                 .returns("9a5fdefae3abb440", TraceContext::parentId);
         }
+    }
+
+    @Test
+    void should_expose_extracted_baggage_to_span_processors_when_starting_span() {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+            .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())
+            .addSpanProcessor(new BaggageTaggingSpanProcessor(Collections.singletonList("foo")))
+            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+            .build();
+        OtelPropagator propagator = new OtelPropagator(contextPropagators,
+                tracerProvider.get("io.micrometer.micrometer-tracing"));
+        Map<String, String> carrier = new HashMap<>();
+        carrier.put("traceparent", "00-3e425f2373d89640bde06e8285e7bf88-9a5fdefae3abb440-01");
+        carrier.put("baggage", "foo=bar");
+
+        propagator.extract(carrier, Map::get).kind(Span.Kind.SERVER).start().end();
+
+        SpanData finishedSpan = exporter.getFinishedSpanItems().get(0);
+        assertThat(finishedSpan.getTraceId()).isEqualTo("3e425f2373d89640bde06e8285e7bf88");
+        assertThat(finishedSpan.getAttributes().get(AttributeKey.stringKey("foo"))).isEqualTo("bar");
     }
 
 }

--- a/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilderTests.java
+++ b/micrometer-tracing-bridges/micrometer-tracing-bridge-otel/src/test/java/io/micrometer/tracing/otel/bridge/OtelSpanBuilderTests.java
@@ -18,9 +18,12 @@ package io.micrometer.tracing.otel.bridge;
 import io.micrometer.tracing.Link;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -33,6 +36,7 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -165,6 +169,54 @@ class OtelSpanBuilderTests {
         map.put("tag1", "value1");
         map.put("tag2", "value2");
         return map;
+    }
+
+    @Test
+    void should_start_span_with_baggage_stored_in_parent_trace_context() {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+            .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())
+            .addSpanProcessor(new BaggageTaggingSpanProcessor(Arrays.asList("foo", "current")))
+            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+            .build();
+        io.opentelemetry.api.trace.Tracer tracer = tracerProvider.get("io.micrometer.micrometer-tracing");
+        io.opentelemetry.api.trace.Span parentSpan = tracer.spanBuilder("parent").startSpan();
+        // e.g. what OtelPropagator#extract produces: the baggage lives in the stored
+        // context only
+        Context storedContext = Context.root().with(parentSpan).with(Baggage.builder().put("foo", "bar").build());
+        TraceContext parent = new OtelTraceContext(storedContext, parentSpan.getSpanContext(), parentSpan);
+
+        Span child;
+        try (Scope scope = Baggage.builder().put("current", "value").build().makeCurrent()) {
+            child = new OtelSpanBuilder(tracer).name("child").setParent(parent).start();
+        }
+        child.end();
+
+        SpanData finishedSpan = exporter.getFinishedSpanItems().get(0);
+        then(finishedSpan.getParentSpanId()).isEqualTo(parentSpan.getSpanContext().getSpanId());
+        then(finishedSpan.getAttributes().get(AttributeKey.stringKey("foo"))).isEqualTo("bar");
+        then(finishedSpan.getAttributes().get(AttributeKey.stringKey("current"))).isEqualTo("value");
+    }
+
+    @Test
+    void should_prefer_baggage_stored_in_parent_trace_context_over_current_baggage() {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+            .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())
+            .addSpanProcessor(new BaggageTaggingSpanProcessor(Collections.singletonList("foo")))
+            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+            .build();
+        io.opentelemetry.api.trace.Tracer tracer = tracerProvider.get("io.micrometer.micrometer-tracing");
+        io.opentelemetry.api.trace.Span parentSpan = tracer.spanBuilder("parent").startSpan();
+        Context storedContext = Context.root().with(parentSpan).with(Baggage.builder().put("foo", "stored").build());
+        TraceContext parent = new OtelTraceContext(storedContext, parentSpan.getSpanContext(), parentSpan);
+
+        try (Scope scope = Baggage.builder().put("foo", "current").build().makeCurrent()) {
+            new OtelSpanBuilder(tracer).name("child").setParent(parent).start().end();
+        }
+
+        SpanData finishedSpan = exporter.getFinishedSpanItems().get(0);
+        then(finishedSpan.getAttributes().get(AttributeKey.stringKey("foo"))).isEqualTo("stored");
     }
 
 }


### PR DESCRIPTION
Fixes #933.

### Problem

With the OTel bridge, fields configured as baggage tag fields are not applied to the span of an incoming request unless the application itself calls `tracer.getBaggage(...)` (or otherwise touches the baggage through the Tracer API). The baggage *is* extracted and *is* propagated further, so the symptom is only visible on the spans: the `traceparent` is honoured, the baggage becomes current inside the handler, but the tags are missing.

### Root cause

`OtelPropagator#extract` returns an `OtelTraceContext` that keeps the full extracted `Context` (span + baggage). `OtelSpanBuilder#start` however calls `spanBuilder.setParent(OtelTraceContext.toOtelContext(parent))`, and `toOtelContext` builds the parent from `Context.current()` plus the parent span only. The baggage stored in the trace context is dropped at that point, so `SpanProcessor#onStart(parentContext, span)` (e.g. `BaggageTaggingSpanProcessor`) and `Sampler#shouldSample` see a parent context without the request's baggage. The baggage only becomes current later, when `OtelCurrentTraceContext#newScope` merges the stored context in — which is why an explicit `getBaggage()` call in the handler "fixes" it.

I confirmed this with a probe on Spring Boot 4.1.1 and `main` (HTTP and gRPC server spans): `BaggageTaggingSpanProcessor#onStart` is invoked with `Baggage.fromContext(parentContext)` empty for every server span, while `Baggage.current()` inside the handler contains the extracted entries.

### Fix

`OtelSpanBuilder#start` now merges the baggage stored in the parent `OtelTraceContext` into the parent `Context` used to start the span. Entries from the trace context take precedence over the current baggage, consistent with `OtelCurrentTraceContext#newScope`. `toOtelContext` itself (also used by `OtelPropagator#inject`) is unchanged.

### Tests

- `OtelSpanBuilderTests`: baggage stored in the parent trace context is visible to a `BaggageTaggingSpanProcessor` when the child starts, current baggage is kept, stored entries win on conflict.
- `OtelPropagatorTests`: end-to-end reproducer — extract `traceparent` + `baggage: foo=bar`, start the SERVER span, the span carries `foo=bar`.

All three fail without the change in `OtelSpanBuilder` and pass with it; the rest of `micrometer-tracing-bridge-otel` is unaffected (94 tests).

Targets `1.6.x` as the oldest maintained line; the affected code is identical on `1.7.x` and `main`.
